### PR TITLE
Remove optional name variable in newtmgr conn add command

### DIFF
--- a/newtmgr/cli/connprofile.go
+++ b/newtmgr/cli/connprofile.go
@@ -45,8 +45,6 @@ func connProfileAddCmd(cmd *cobra.Command, args []string) {
 	for _, vdef := range args[1:] {
 		s := strings.SplitN(vdef, "=", 2)
 		switch s[0] {
-		case "name":
-			cp.Name = s[1]
 		case "type":
 			var err error
 			cp.Type, err = config.ConnTypeFromString(s[1])


### PR DESCRIPTION
The usage for the optional "name" variable in the "newtmgr conn add" command seems redundant and confusing. When the variable is set in the command, the value overrides the required <conn_profile> parameter. The user must then use the value specfied for the name variable and not the <conn_profile> value to refer the connection profile.  It seems the user can just specify the name he wants to use in the <conn_profile>.

Chris and I discussed this and decided to remove the variable to simply documentation.