### PR TITLE
Merge 1.0 newtmgr help text updates into new newtmgr repo

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -54,7 +54,7 @@ func Commands() *cobra.Command {
 	}
 
 	nmCmd.PersistentFlags().StringVarP(&nmutil.ConnProfile, "conn", "c", "",
-		"connection profile to use.")
+		"connection profile to use")
 
 	nmCmd.PersistentFlags().Float64VarP(&nmutil.Timeout, "timeout", "t", 10.0,
 		"timeout in seconds (partial seconds allowed)")

--- a/newtmgr/cli/config.go
+++ b/newtmgr/cli/config.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func configRead(s sesn.Sesn, args []string) {
@@ -83,9 +83,12 @@ func configRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func configCmd() *cobra.Command {
+	configCmdLongHelp := "Read or write a config value for <var-name> variable on " +
+		"a device.\nSpecify a var-value to write a value to a device.\n"
 	configCmd := &cobra.Command{
-		Use:   "config <name> [val]",
-		Short: "Read or write config value on target",
+		Use:   "config <var-name> [var-value] -c <conn_profile>",
+		Short: "Read or write a config value on a device",
+		Long:  configCmdLongHelp,
 		Run:   configRunCmd,
 	}
 

--- a/newtmgr/cli/crash.go
+++ b/newtmgr/cli/crash.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func crashRunCmd(cmd *cobra.Command, args []string) {
@@ -67,8 +67,8 @@ func crashCmd() *cobra.Command {
 
 	namesStr := strings.Join(xact.CrashTypeNames(), "|")
 	crashCmd := &cobra.Command{
-		Use:     "crash [" + namesStr + "]",
-		Short:   "Send crash command to remote endpoint using newtmgr",
+		Use:     "crash <" + namesStr + "> -c <conn_profiles>",
+		Short:   "Send a crash command to a device",
 		Example: crashEx,
 		Run:     crashRunCmd,
 	}

--- a/newtmgr/cli/datetime.go
+++ b/newtmgr/cli/datetime.go
@@ -57,7 +57,7 @@ func dateTimeWrite(s sesn.Sesn, args []string) error {
 
 	sres := res.(*xact.DateTimeWriteResult)
 	if sres.Rsp.Rc != 0 {
-		fmt.Printf("Error: %c\n", sres.Rsp.Rc)
+		fmt.Printf("Error: %d\n", sres.Rsp.Rc)
 	} else {
 		fmt.Printf("Done\n")
 	}

--- a/newtmgr/cli/datetime.go
+++ b/newtmgr/cli/datetime.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func dateTimeRead(s sesn.Sesn) error {
@@ -83,18 +83,29 @@ func dateTimeRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func dateTimeCmd() *cobra.Command {
-	dateTimeCmd := &cobra.Command{
-		Use:   "datetime [rfc-3339-date-string]",
-		Short: "Manage datetime on the device",
-		Long: "Manage datetime on the device\n" +
-			"Example RFC 3339 strings:\n" +
-			"2016-03-02T22:44:00                  UTC time (implicit)\n" +
-			"2016-03-02T22:44:00Z                 UTC time (explicit)\n" +
-			"2016-03-02T22:44:00-08:00            PST timezone\n" +
-			"2016-03-02T22:44:00.1                fractional seconds\n" +
-			"2016-03-02T22:44:00.101+05:30        fractional seconds with timezone\n",
+	dateTimeHelpText := "Display or set datetime on a device. "
+	dateTimeHelpText += "Specify a datetime-value\n"
+	dateTimeHelpText += "to set the datetime on the device.\n\n"
+	dateTimeHelpText += "Must specify datetime-value in RFC 3339 format.\n"
 
-		Run: dateTimeRunCmd,
+	dateTimeEx := "newtmgr datetime -c myserial\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00 -c myserial"
+	dateTimeEx += "             (implicit UTC) \n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00Z -c myserial"
+	dateTimeEx += "            (explicit UTC)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00-08:00 -c myserial"
+	dateTimeEx += "       (PST)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.1 -c myserial"
+	dateTimeEx += "           (fractional secs)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.101+05:30 -c myserial"
+	dateTimeEx += "   (fractional secs + timezone)\n"
+
+	dateTimeCmd := &cobra.Command{
+		Use:     "datetime [rfc-3339-date-string] -c <conn_profile>",
+		Short:   "Manage datetime on a device",
+		Long:    dateTimeHelpText,
+		Example: dateTimeEx,
+		Run:     dateTimeRunCmd,
 	}
 
 	return dateTimeCmd

--- a/newtmgr/cli/echo.go
+++ b/newtmgr/cli/echo.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func echoRunCmd(cmd *cobra.Command, args []string) {
@@ -54,8 +54,8 @@ func echoRunCmd(cmd *cobra.Command, args []string) {
 
 func echoCmd() *cobra.Command {
 	echoCmd := &cobra.Command{
-		Use:   "echo",
-		Short: "Send data to remote endpoint using newtmgr, and receive data back",
+		Use:   "echo <text> -c <conn_profile>",
+		Short: "Send data to a device and display the echoed back data",
 		Run:   echoRunCmd,
 	}
 

--- a/newtmgr/cli/fs.go
+++ b/newtmgr/cli/fs.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func fsDownloadRunCmd(cmd *cobra.Command, args []string) {
@@ -115,7 +115,7 @@ func fsUploadRunCmd(cmd *cobra.Command, args []string) {
 func fsCmd() *cobra.Command {
 	fsCmd := &cobra.Command{
 		Use:   "fs",
-		Short: "Access files on device",
+		Short: "Access files on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -124,8 +124,8 @@ func fsCmd() *cobra.Command {
 	uploadEx := "  newtmgr -c olimex fs upload sample.lua /sample.lua\n"
 
 	uploadCmd := &cobra.Command{
-		Use:     "upload <src-filename> <dst-filename>",
-		Short:   "Upload file to target",
+		Use:     "upload <src-filename> <dst-filename> -c <conn_profile>",
+		Short:   "Upload file to a device",
 		Example: uploadEx,
 		Run:     fsUploadRunCmd,
 	}
@@ -134,8 +134,8 @@ func fsCmd() *cobra.Command {
 	downloadEx := "  newtmgr -c olimex image download /cfg/mfg mfg.txt\n"
 
 	downloadCmd := &cobra.Command{
-		Use:     "download <src-filename> <dst-filename>",
-		Short:   "Download file from target",
+		Use:     "download <src-filename> <dst-filename> -c <conn_profile>",
+		Short:   "Download file from a device",
 		Example: downloadEx,
 		Run:     fsDownloadRunCmd,
 	}

--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -343,15 +343,15 @@ func coreConvertCmd(cmd *cobra.Command, args []string) {
 func imageCmd() *cobra.Command {
 	imageCmd := &cobra.Command{
 		Use:   "image",
-		Short: "Manage images on remote instance",
+		Short: "Manage images on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
 	}
 
 	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "Show target images",
+		Use:   "list -c <conn_profile>",
+		Short: "Show images on a device",
 		Run:   imageStateListCmd,
 	}
 	imageCmd.AddCommand(listCmd)
@@ -364,7 +364,7 @@ func imageCmd() *cobra.Command {
 	imageCmd.AddCommand(testCmd)
 
 	confirmCmd := &cobra.Command{
-		Use:   "confirm [hex-image-hash]",
+		Use:   "confirm [hex-image-hash] -c <conn_profile>",
 		Short: "Permanently run image",
 		Long: "If a hash is specified, permanently switch to the " +
 			"corresponding image.  If no hash is specified, the current " +
@@ -373,33 +373,31 @@ func imageCmd() *cobra.Command {
 	}
 	imageCmd.AddCommand(confirmCmd)
 
-	uploadEx := "  newtmgr -c olimex image upload <image_file>\n"
-	uploadEx +=
+	uploadEx :=
 		"  newtmgr -c olimex image upload bin/slinky_zero/apps/slinky.img\n"
 
 	uploadCmd := &cobra.Command{
-		Use:     "upload",
-		Short:   "Upload image to target",
+		Use:     "upload <image-file> -c <conn_profile>",
+		Short:   "Upload image to a device",
 		Example: uploadEx,
 		Run:     imageUploadCmd,
 	}
 	imageCmd.AddCommand(uploadCmd)
 
 	coreListCmd := &cobra.Command{
-		Use:     "corelist",
-		Short:   "List core(s) on target",
+		Use:     "corelist -c <conn_profile>",
+		Short:   "List core(s) on a device",
 		Example: "  newtmgr -c olimex image corelist\n",
 		Run:     coreListCmd,
 	}
 	imageCmd.AddCommand(coreListCmd)
 
-	coreEx := "  newtmgr -c olimex image coredownload -e <filename>\n"
-	coreEx += "  newtmgr -c olimex image coredownload -e core\n"
+	coreEx := "  newtmgr -c olimex image coredownload -e core\n"
 	coreEx += "  newtmgr -c olimex image coredownload --offset 10 -n 10 core\n"
 
 	coreDownloadCmd := &cobra.Command{
-		Use:     "coredownload <dst-filename>",
-		Short:   "Download core from target",
+		Use:     "coredownload <core-file> -c <conn_profile>",
+		Short:   "Download core from a device",
 		Example: coreEx,
 		Run:     coreDownloadCmd,
 	}
@@ -413,22 +411,22 @@ func imageCmd() *cobra.Command {
 	coreEraseEx := "  newtmgr -c olimex image coreerase\n"
 
 	coreEraseCmd := &cobra.Command{
-		Use:     "coreerase",
-		Short:   "Erase core on target",
+		Use:     "coreerase -c <conn_profile>",
+		Short:   "Erase core on a device",
 		Example: coreEraseEx,
 		Run:     coreEraseCmd,
 	}
 	imageCmd.AddCommand(coreEraseCmd)
 
-	imageEraseHelpText := "Erases an unused image from the secondary image slot on a device.\n"
+	imageEraseHelpText := "Erase an unused image from the secondary image slot on a device.\n"
 	imageEraseHelpText += "The image cannot be erased if the image is a confirmed image, is marked\n"
 	imageEraseHelpText += "for test on the next reboot, or is an active image for a split image setup.\n"
 
 	imageEraseEx := "  newtmgr -c olimex image erase\n"
 
 	imageEraseCmd := &cobra.Command{
-		Use:     "erase",
-		Short:   "Erase unused image on target",
+		Use:     "erase -c <conn_profile>",
+		Short:   "Erase unused image on a device",
 		Long:    imageEraseHelpText,
 		Example: imageEraseEx,
 		Run:     imageEraseCmd,
@@ -437,7 +435,7 @@ func imageCmd() *cobra.Command {
 
 	coreConvertCmd := &cobra.Command{
 		Use:   "coreconvert <core-filename> <elf-filename>",
-		Short: "Convert core to elf",
+		Short: "Convert core to ELF",
 		Run:   coreConvertCmd,
 	}
 	imageCmd.AddCommand(coreConvertCmd)

--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func logShowCmd(cmd *cobra.Command, args []string) {
@@ -220,44 +220,44 @@ func logClearCmd(cmd *cobra.Command, args []string) {
 func logCmd() *cobra.Command {
 	logCmd := &cobra.Command{
 		Use:   "log",
-		Short: "Handles log on remote instance",
+		Short: "Manage logs on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
 	}
 
 	showCmd := &cobra.Command{
-		Use:   "show [log-name] [min-index] [min-timestamp]",
-		Short: "Show log on target",
+		Use:   "show [log-name] [min-index] [min-timestamp] -c <conn_profile>",
+		Short: "Show the logs on a device",
 		Run:   logShowCmd,
 	}
 	logCmd.AddCommand(showCmd)
 
 	clearCmd := &cobra.Command{
-		Use:   "clear",
-		Short: "Clear log on target",
+		Use:   "clear -c <conn_profile>",
+		Short: "Clear the logs on a device",
 		Run:   logClearCmd,
 	}
 	logCmd.AddCommand(clearCmd)
 
 	moduleListCmd := &cobra.Command{
-		Use:   "module_list",
-		Short: "Module List Command",
+		Use:   "module_list -c <conn_profile>",
+		Short: "Show the log module names",
 		Run:   logModuleListCmd,
 	}
 	logCmd.AddCommand(moduleListCmd)
 
 	levelListCmd := &cobra.Command{
-		Use:   "level_list",
-		Short: "Level List Command",
+		Use:   "level_list -c <conn_profile>",
+		Short: "Show the log levels",
 		Run:   logLevelListCmd,
 	}
 
 	logCmd.AddCommand(levelListCmd)
 
 	ListCmd := &cobra.Command{
-		Use:   "list",
-		Short: "Log List Command",
+		Use:   "list -c <conn_profile>",
+		Short: "Show the log names",
 		Run:   logListCmd,
 	}
 

--- a/newtmgr/cli/mpstat.go
+++ b/newtmgr/cli/mpstat.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func mempoolStatRunCmd(cmd *cobra.Command, args []string) {
@@ -70,8 +70,8 @@ func mempoolStatRunCmd(cmd *cobra.Command, args []string) {
 
 func mempoolStatCmd() *cobra.Command {
 	mempoolStatCmd := &cobra.Command{
-		Use:   "mpstat",
-		Short: "Read mempool statistics from a remote endpoint",
+		Use:   "mpstat -c <conn_profile>",
+		Short: "Read mempool statistics from a device",
 		Run:   mempoolStatRunCmd,
 	}
 

--- a/newtmgr/cli/reset.go
+++ b/newtmgr/cli/reset.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func resetRunCmd(cmd *cobra.Command, args []string) {
@@ -47,8 +47,8 @@ func resetRunCmd(cmd *cobra.Command, args []string) {
 
 func resetCmd() *cobra.Command {
 	resetCmd := &cobra.Command{
-		Use:   "reset",
-		Short: "Performs a soft reset of target device",
+		Use:   "reset -c <conn_profile>",
+		Short: "Perform a soft reset of a device",
 		Run:   resetRunCmd,
 	}
 

--- a/newtmgr/cli/run.go
+++ b/newtmgr/cli/run.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func runTestCmd(cmd *cobra.Command, args []string) {
@@ -92,7 +92,7 @@ func runListCmd(cmd *cobra.Command, args []string) {
 func runCmd() *cobra.Command {
 	runCmd := &cobra.Command{
 		Use:   "run",
-		Short: "Run procedures on remote device",
+		Short: "Run test procedures on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -100,18 +100,23 @@ func runCmd() *cobra.Command {
 
 	runtestEx := "  newtmgr -c conn run test all 201612161220"
 
+	runTestHelpText := "Run tests on a device. Specify a testname to run a "
+	runTestHelpText += "specific test. All tests are\nrun if \"all\" or no "
+	runTestHelpText += "testname is specified. If a token-value is "
+	runTestHelpText += "specified, the\nvalue is output on the log messages.\n"
+
 	runTestCmd := &cobra.Command{
-		Use: "test [all | testname] [token]",
-		Short: "Run commands on remote device - \"token\" output on log " +
-			"messages",
+		Use:     "test [all | testname] [token] -c <conn_profile>",
+		Short:   "Run tests on a device",
+		Long:    runTestHelpText,
 		Example: runtestEx,
 		Run:     runTestCmd,
 	}
 	runCmd.AddCommand(runTestCmd)
 
 	runListCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List registered commands on remote device",
+		Use:   "list -c <conn_profile>",
+		Short: "List registered tests on a device",
 		Run:   runListCmd,
 	}
 	runCmd.AddCommand(runListCmd)

--- a/newtmgr/cli/stat.go
+++ b/newtmgr/cli/stat.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func statsListRunCmd(cmd *cobra.Command, args []string) {
@@ -104,15 +104,17 @@ func statsRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func statsCmd() *cobra.Command {
+	statsHelpText := "Read statistics for the specified stats_name from a device"
 	statsCmd := &cobra.Command{
-		Use:   "stat",
-		Short: "Read statistics from a remote endpoint",
+		Use:   "stat <stats_name> -c <conn_profile>",
+		Short: "Read statistics from a device",
+		Long:  statsHelpText,
 		Run:   statsRunCmd,
 	}
 
 	ListCmd := &cobra.Command{
-		Use:   "list",
-		Short: "Read list of statistics from a remote endpoint",
+		Use:   "list -c <conn_profile>",
+		Short: "Read the list of Stats names from a device",
 		Run:   statsListRunCmd,
 	}
 

--- a/newtmgr/cli/taskstat.go
+++ b/newtmgr/cli/taskstat.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
-	"mynewt.apache.org/newt/util"
 )
 
 func taskStatRunCmd(cmd *cobra.Command, args []string) {
@@ -76,8 +76,8 @@ func taskStatRunCmd(cmd *cobra.Command, args []string) {
 
 func taskStatCmd() *cobra.Command {
 	taskStatCmd := &cobra.Command{
-		Use:   "taskstat",
-		Short: "Read statistics from a remote endpoint",
+		Use:   "taskstat -c <conn_profile>",
+		Short: "Read task statistics from a device",
 		Run:   taskStatRunCmd,
 	}
 


### PR DESCRIPTION
Some help text updates added for newtmgr commands for 1.0 (newt repos) did not get merged into the newtmgr repo.  This PR merges the help text updates from 1.0 newt repo to the newtmgr repo. 