### PR TITLE
Fixed newt log show parameter syntax.

### DIFF
--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -228,17 +228,32 @@ func logCmd() *cobra.Command {
 		},
 	}
 
+	logShowHelpText := "Show logs on a device.  Optional log-name, min-index, and min-timestamp\nparameters can be specified to filter the logs to display.\n\n"
+	logShowHelpText += "- log-name specifies the log to display.  If log-name is not specified, all\nlogs are displayed.\n\n"
+	logShowHelpText += "- min-index specifies to only display the log entries with an index value equal to or higher than min-index.  "
+	logShowHelpText += "If \"last\"  is specified for min-index, the last\nlog entry is displayed.\n\n"
+	logShowHelpText += "- min-timestamp specifies to only display the log entries with a timestamp\nequal to or later than min-timestamp. Log entries with a timestamp equal to\nmin-timestamp are only displayed if the entry index is equal to or higher than min-index.\n"
+
+	logShowEx := "newtmgr log show -c myserial\n"
+	logShowEx += "newtmgr log show reboot_log -c myserial\n"
+	logShowEx += "newtmgr log show reboot_log last -c myserial\n"
+	logShowEx += "newtmgr log show reboot_log 5 -c myserial\n"
+	logShowEx += "newtmgr log show reboot_log 3 1122222 -c myserial\n"
+
 	showCmd := &cobra.Command{
-		Use:   "show [log-name] [min-index] [min-timestamp] -c <conn_profile>",
-		Short: "Show the logs on a device",
-		Run:   logShowCmd,
+		Use:     "show [log-name [min-index [min-timestamp]]] -c <conn_profile>",
+		Example: logShowEx,
+		Long:    logShowHelpText,
+		Short:   "Show the logs on a device",
+		Run:     logShowCmd,
 	}
 	logCmd.AddCommand(showCmd)
 
 	clearCmd := &cobra.Command{
-		Use:   "clear -c <conn_profile>",
-		Short: "Clear the logs on a device",
-		Run:   logClearCmd,
+		Use:     "clear -c <conn_profile>",
+		Short:   "Clear the logs on a device",
+		Example: logShowEx,
+		Run:     logClearCmd,
 	}
 	logCmd.AddCommand(clearCmd)
 


### PR DESCRIPTION
Fixed newt log show parameter syntax.
Also added more help text and examples in command usage