### PR TITLE
Reduce default MTU from 527 to 512.

### DIFF
--- a/newtmgr/bll/bll_sesn_cfg.go
+++ b/newtmgr/bll/bll_sesn_cfg.go
@@ -36,7 +36,7 @@ type BllSesnCfg struct {
 
 func NewBllSesnCfg() BllSesnCfg {
 	return BllSesnCfg{
-		PreferredMtu: 527,
+		PreferredMtu: 512,
 		ConnTimeout:  10 * time.Second,
 	}
 }


### PR DESCRIPTION
Under linux, the currantlabs/ble library was rejecting an attempt to set an ATT MTU > 512 with the error "Invalid argument".