### PR TITLE
MYNEWT-822 newtmgr - Native BLE - reconnect on immediate supervision timeout

### DIFF
--- a/newtmgr/bll/bll_sesn_cfg.go
+++ b/newtmgr/bll/bll_sesn_cfg.go
@@ -32,11 +32,13 @@ type BllSesnCfg struct {
 	AdvFilter    ble.AdvFilter
 	PreferredMtu int
 	ConnTimeout  time.Duration
+	ConnTries    int
 }
 
 func NewBllSesnCfg() BllSesnCfg {
 	return BllSesnCfg{
 		PreferredMtu: 527,
 		ConnTimeout:  10 * time.Second,
+		ConnTries:    3,
 	}
 }


### PR DESCRIPTION
(https://issues.apache.org/jira/browse/MYNEWT-822)

The first data packet to be exchanged over a BLE connection has a high probability of triggering a disconnect. The sending controller uses this packet to determine if the connection attempt was successful in the first place, and it does not get retried if it gets dropped.

In the case of newtmgr, the first data packet gets sent during ATT MTU negotiation. The bhd (blehostd) transports recover from a disconnect during ATT MTU negotiation by reopening the session.

The ble transports (native BLE) do not recover from such a disconnect. We should add the same recovery logic for the ble transports that has already been implemented for bhd.