### PR TITLE
conn.go; BleDev.String() in bledefs/bledefs.go takes in pointer to

### DIFF
--- a/nmxact/nmble/conn.go
+++ b/nmxact/nmble/conn.go
@@ -378,7 +378,7 @@ func (c *Conn) Connect(bx *BleXport, ownAddrType BleAddrType, peer BleDev,
 		if bhe != nil && bhe.Status == ERR_CODE_EDONE {
 			// Already connected.
 			c.rxvr.RemoveListener("connect", bl)
-			return fmt.Errorf("Already connected to peer %s", peer)
+			return fmt.Errorf("Already connected to peer %s", &peer)
 		} else if !nmxutil.IsXport(err) {
 			// The transport did not restart; always attempt to cancel the
 			// connect operation.  In most cases, the host has already stopped


### PR DESCRIPTION
BleDev, instead of value. Change the call to printf() to pass pointer
to peer, instead of it's value.