### PR TITLE
nmxact - Stop syncer on xport startup.

### DIFF
--- a/nmxact/nmble/ble_xport.go
+++ b/nmxact/nmble/ble_xport.go
@@ -341,6 +341,10 @@ func (bx *BleXport) startEvent() error {
 		return err
 	}
 
+	// Make sure we don't think we are still in sync with the controller.  If
+	// we fail early, we don't want to try sending a reset command.
+	bx.syncer.Stop()
+
 	if err := bx.startUnixChild(); err != nil {
 		return fail(err)
 	}

--- a/nmxact/nmble/sync.go
+++ b/nmxact/nmble/sync.go
@@ -190,6 +190,8 @@ func (s *Syncer) Stop() error {
 		return err
 	}
 
+	s.synced = false
+
 	close(s.stopCh)
 
 	close(s.syncCh)


### PR DESCRIPTION
This prevents a hang that occurs due to the following sequence:

1. BLE transport successfully starts.
2. For some reason, the transport needs to be reset.
3. Blehostd fails to start.

Step 3 triggers a transport shutdown.  Prior to this change, the
transport might appear to still be in sync, which causes the transport
to send a `reset` command to blehostd.  Since blehostd is not running,
the code hangs.