### PR TITLE
nmxact - conn_cancel_evt listener uses wrong seq

### DIFF
--- a/nmxact/nmble/ble_act.go
+++ b/nmxact/nmble/ble_act.go
@@ -76,6 +76,11 @@ func connect(x *BleXport, bl *Listener, r *BleConnectReq) (uint16, error) {
 					return 0, nmxutil.NewBleHostError(msg.Status, str)
 				}
 
+			case *BleConnCancelEvt:
+				str := "BLE connection attempt cancelled"
+				log.Debugf(str)
+				return 0, fmt.Errorf("%s", str)
+
 			default:
 			}
 
@@ -163,7 +168,8 @@ func connCancel(x *BleXport, bl *Listener, r *BleConnCancelReq) error {
 				bl.Acked = true
 				switch msg.Status {
 				case 0:
-					// Cancel initiated.  Await cancel event.
+					// Cancel initiated.  Await connect failure.
+					return nil
 
 				case ERR_CODE_EALREADY:
 					// No connect in progress.  Pretend success.
@@ -172,10 +178,6 @@ func connCancel(x *BleXport, bl *Listener, r *BleConnCancelReq) error {
 				default:
 					return StatusError(MSG_OP_RSP, rspType, msg.Status)
 				}
-
-			case *BleConnCancelEvt:
-				// Connection successfully cancelled.
-				return nil
 
 			default:
 			}


### PR DESCRIPTION
When blehostd sends a `conn_cancel_evt` event, it uses the sequence
number associated with the connection, not the sequence number
corresponding to the `conn_cancel` request.

Prior to this change, nmxact would listen for the `conn_cancel_evt` with
a sequence number equal to that of the request.  The event would never
arrive, which caused the transport to be restarted.

Now, the connect listener listens for the cancel event, in addition to
the connect event.