### PR TITLE
image upload; add support for specifying max mtu to use for serial

### DIFF
--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -42,6 +42,8 @@ var (
 	coreNumBytes uint32
 )
 
+var noerase bool
+
 func imageFlagsStr(image nmp.ImageStateEntry) string {
 	strs := []string{}
 
@@ -184,6 +186,9 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 	c := xact.NewImageUpgradeCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Data = imageFile
+	if noerase == true {
+		c.NoErase = true
+	}
 	c.ProgressBar = pb.StartNew(len(imageFile))
 	c.ProgressBar.SetUnits(pb.U_BYTES)
 	c.LastOff = 0
@@ -387,6 +392,9 @@ func imageCmd() *cobra.Command {
 		Example: uploadEx,
 		Run:     imageUploadCmd,
 	}
+	uploadCmd.PersistentFlags().BoolVarP(&noerase,
+		"noerase", "e", false,
+		"Don't send specific image erase command to start with")
 	imageCmd.AddCommand(uploadCmd)
 
 	coreListCmd := &cobra.Command{

--- a/newtmgr/config/serial_config.go
+++ b/newtmgr/config/serial_config.go
@@ -61,6 +61,13 @@ func ParseSerialConnString(cs string) (*nmserial.XportCfg, error) {
 				return sc, einvalSerialConnString("Invalid baud: %s", v)
 			}
 
+		case "mtu":
+			var err error
+			sc.Mtu, err = strconv.Atoi(v)
+			if err != nil {
+				return sc, einvalSerialConnString("Invalid mtu: %s", v)
+			}
+
 		default:
 			return sc, einvalSerialConnString("Unrecognized key: %s", k)
 		}

--- a/nmxact/nmserial/serial_sesn.go
+++ b/nmxact/nmserial/serial_sesn.go
@@ -108,7 +108,7 @@ func (s *SerialSesn) MtuIn() int {
 func (s *SerialSesn) MtuOut() int {
 	// Mynewt commands have a default chunk buffer size of 512.  Account for
 	// base64 encoding.
-	return 512*3/4 - omp.OMP_MSG_OVERHEAD
+	return s.sx.cfg.Mtu*3/4 - omp.OMP_MSG_OVERHEAD
 }
 
 func (s *SerialSesn) AbortRx(seq uint8) error {

--- a/nmxact/nmserial/serial_xport.go
+++ b/nmxact/nmserial/serial_xport.go
@@ -39,12 +39,14 @@ import (
 type XportCfg struct {
 	DevPath     string
 	Baud        int
+	Mtu         int
 	ReadTimeout time.Duration
 }
 
 func NewXportCfg() *XportCfg {
 	return &XportCfg{
 		ReadTimeout: 10 * time.Second,
+		Mtu: 512,
 	}
 }
 

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -169,6 +169,7 @@ func (c *ImageUploadCmd) Run(s sesn.Sesn) (Result, error) {
 type ImageUpgradeCmd struct {
 	CmdBase
 	Data        []byte
+	NoErase     bool
 	ProgressCb  ImageUploadProgressFn
 	LastOff     uint32
 	ProgressBar *pb.ProgressBar
@@ -182,6 +183,7 @@ type ImageUpgradeResult struct {
 func NewImageUpgradeCmd() *ImageUpgradeCmd {
 	return &ImageUpgradeCmd{
 		CmdBase: NewCmdBase(),
+		NoErase: false,
 	}
 }
 
@@ -259,11 +261,17 @@ func (c *ImageUpgradeCmd) runUpload(s sesn.Sesn) (*ImageUploadResult, error) {
 }
 
 func (c *ImageUpgradeCmd) Run(s sesn.Sesn) (Result, error) {
-	eres, err := c.runErase(s)
-	if err != nil {
-		return nil, err
-	}
+	var eres *ImageEraseResult = nil
+	var err error
 
+	if c.NoErase == false {
+		eres, err = c.runErase(s)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		eres = nil
+	}
 	ures, err := c.runUpload(s)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
newtmgr. Add '-e' flag to image upload which stops upload from
starting with erase flash command.