### PR TITLE
newtmgr - CLI options to specify connprofile flds

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -71,6 +71,16 @@ func Commands() *cobra.Command {
 	nmCmd.PersistentFlags().BoolVar(&nmutil.BleWriteRsp, "write-rsp", false,
 		"Send BLE acked write requests instead of unacked write commands")
 
+	nmCmd.PersistentFlags().StringVar(&nmutil.ConnType, "conntype", "",
+		"Connection type to use instead of using the profile's type")
+
+	nmCmd.PersistentFlags().StringVar(&nmutil.ConnString, "connstring", "",
+		"Connection key-value pairs to use instead of using the profile's "+
+			"connstring")
+
+	nmCmd.PersistentFlags().StringVar(&nmutil.ConnExtra, "connextra", "",
+		"Additional key-value pair to append to the connstring")
+
 	nmCmd.AddCommand(crashCmd())
 	nmCmd.AddCommand(dateTimeCmd())
 	nmCmd.AddCommand(fsCmd())

--- a/newtmgr/config/connprofile.go
+++ b/newtmgr/config/connprofile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"sort"
@@ -41,6 +42,11 @@ type ConnProfile struct {
 	Name       string   `json:"MyName"`
 	Type       ConnType `json:"MyType"`
 	ConnString string   `json:"MyConnString"`
+}
+
+func (p *ConnProfile) String() string {
+	return fmt.Sprintf("name=%s type=%s connstring=%s",
+		p.Name, ConnTypeToString(p.Type), p.ConnString)
 }
 
 const (
@@ -234,10 +240,6 @@ func (cpm *ConnProfileMgr) AddConnProfile(cp *ConnProfile) error {
 func (cpm *ConnProfileMgr) GetConnProfile(pName string) (*ConnProfile, error) {
 	// Each section is a connection profile, key values are the contents
 	// of that section.
-	if pName == "" {
-		return nil, util.NewNewtError("Need to specify connection profile")
-	}
-
 	p := cpm.profiles[pName]
 	if p == nil {
 		return nil, util.FmtNewtError("connection profile \"%s\" doesn't "+

--- a/newtmgr/nmutil/nmutil.go
+++ b/newtmgr/nmutil/nmutil.go
@@ -32,6 +32,9 @@ var Tries int
 var ConnProfile string
 var DeviceName string
 var BleWriteRsp bool
+var ConnType string
+var ConnString string
+var ConnExtra string
 
 func TxOptions() sesn.TxOptions {
 	return sesn.TxOptions{


### PR DESCRIPTION
This commit adds three CLI options:

```
      --connextra string    Additional key-value pair to append to the connstring
      --connstring string   Connection key-value pairs to use instead of using the profile's connstring
      --conntype string     Connection type to use instead of using the profile's type
```

`--conntype` and `--connstring` replace the `type` and `connstring`
values of the connection profile.  If no connection profile is
specified, these options must specify all the necessary connection
settings.

`--connextra` appends fields to the connection profile's `connstring`
value.  This option is only useful when a connection profile is
specified.