### PR TITLE
nmxact; image upload with oic would always try to use Coap over TCP encoding.

### DIFF
--- a/nmxact/mgmt/mgmt.go
+++ b/nmxact/mgmt/mgmt.go
@@ -27,37 +27,20 @@ import (
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
 
-func MtuNmp(rawMtu int) int {
-	return rawMtu - nmp.NMP_HDR_SIZE
-}
-
-func MtuOmp(rawMtu int) int {
-	return rawMtu - omp.OMP_MSG_OVERHEAD - nmp.NMP_HDR_SIZE
-}
-
-func MtuMgmt(rawMtu int, mgmtProto sesn.MgmtProto) (int, error) {
-	switch mgmtProto {
-	case sesn.MGMT_PROTO_NMP:
-		return MtuNmp(rawMtu), nil
-
-	case sesn.MGMT_PROTO_OMP:
-		return MtuOmp(rawMtu), nil
-
-	default:
-		return 0, fmt.Errorf("invalid management protocol: %+v", mgmtProto)
-	}
-}
-
-func EncodeMgmt(mgmtProto sesn.MgmtProto, m *nmp.NmpMsg) ([]byte, error) {
-	switch mgmtProto {
+func EncodeMgmt(s sesn.Sesn, m *nmp.NmpMsg) ([]byte, error) {
+	switch s.MgmtProto() {
 	case sesn.MGMT_PROTO_NMP:
 		return nmp.EncodeNmpPlain(m)
 
 	case sesn.MGMT_PROTO_OMP:
-		return omp.EncodeOmpTcp(m)
+		if s.CoapIsTcp() == true {
+			return omp.EncodeOmpTcp(m)
+		} else {
+			return omp.EncodeOmpDgram(m)
+		}
 
 	default:
 		return nil,
-			fmt.Errorf("invalid management protocol: %+v", mgmtProto)
+			fmt.Errorf("invalid management protocol: %+v", s.MgmtProto())
 	}
 }

--- a/nmxact/xact/fs.go
+++ b/nmxact/xact/fs.go
@@ -142,7 +142,7 @@ func nextFsUploadReq(s sesn.Sesn, name string, data []byte, off int) (
 	// First, build a request without data to determine how much data could
 	// fit.
 	empty := buildFsUploadReq(name, len(data), nil, off)
-	emptyEnc, err := mgmt.EncodeMgmt(s.MgmtProto(), empty.Msg())
+	emptyEnc, err := mgmt.EncodeMgmt(s, empty.Msg())
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func nextFsUploadReq(s sesn.Sesn, name string, data []byte, off int) (
 	// not be valid for some encodings (e.g., CBOR uses variable length fields
 	// to encodes byte string lengths).
 	r := buildFsUploadReq(name, len(data), data[off:off+room], off)
-	enc, err := mgmt.EncodeMgmt(s.MgmtProto(), r.Msg())
+	enc, err := mgmt.EncodeMgmt(s, r.Msg())
 	if err != nil {
 		return nil, err
 	}

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -83,7 +83,7 @@ func nextImageUploadReq(s sesn.Sesn, data []byte, off int) (
 	// First, build a request without data to determine how much data could
 	// fit.
 	empty := buildImageUploadReq(len(data), nil, off)
-	emptyEnc, err := mgmt.EncodeMgmt(s.MgmtProto(), empty.Msg())
+	emptyEnc, err := mgmt.EncodeMgmt(s, empty.Msg())
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func nextImageUploadReq(s sesn.Sesn, data []byte, off int) (
 	// not be valid for some encodings (e.g., CBOR uses variable length fields
 	// to encodes byte string lengths).
 	r := buildImageUploadReq(len(data), data[off:off+room], off)
-	enc, err := mgmt.EncodeMgmt(s.MgmtProto(), r.Msg())
+	enc, err := mgmt.EncodeMgmt(s, r.Msg())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also remove functions which appear to not be used.