### PR TITLE
Flush the serial port before operation

### DIFF
--- a/nmxact/nmserial/serial_xport.go
+++ b/nmxact/nmserial/serial_xport.go
@@ -81,6 +81,11 @@ func (sx *SerialXport) Start() error {
 		return err
 	}
 
+	err = sx.port.Flush()
+	if err != nil {
+		return err
+	}
+
 	// Most of the reading will be done line by line, use the
 	// bufio.Scanner to do this
 	sx.scanner = bufio.NewScanner(sx.port)


### PR DESCRIPTION
Sometimes RX buffer contain unread bytes with
cause failures of the firs transaction. This patch
fix this this problem by flushing the port prior
any operation.