### PR TITLE
newtmgr - Allow metadata to be configured at runtime

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -20,6 +20,8 @@
 package cli
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -34,8 +36,8 @@ var NewtmgrHelp bool
 func Commands() *cobra.Command {
 	logLevelStr := ""
 	nmCmd := &cobra.Command{
-		Use:   "newtmgr",
-		Short: "Newtmgr helps you manage remote devices running the Mynewt OS",
+		Use:   nmutil.ToolInfo.ExeName,
+		Short: nmutil.ToolInfo.ShortName + " helps you manage remote devices running the Mynewt OS",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			NewtmgrLogLevel, err := log.ParseLevel(logLevelStr)
 			if err != nil {
@@ -80,6 +82,18 @@ func Commands() *cobra.Command {
 
 	nmCmd.PersistentFlags().StringVar(&nmutil.ConnExtra, "connextra", "",
 		"Additional key-value pair to append to the connstring")
+
+	versCmd := &cobra.Command{
+		Use:     "version",
+		Short:   "Display the " + nmutil.ToolInfo.ShortName + " version number",
+		Example: "  " + nmutil.ToolInfo.ExeName + " version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%s %s\n",
+				nmutil.ToolInfo.LongName,
+				nmutil.ToolInfo.VersionString)
+		},
+	}
+	nmCmd.AddCommand(versCmd)
 
 	nmCmd.AddCommand(crashCmd())
 	nmCmd.AddCommand(dateTimeCmd())

--- a/newtmgr/cli/connprofile.go
+++ b/newtmgr/cli/connprofile.go
@@ -25,6 +25,7 @@ import (
 
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/config"
+	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 
 	"github.com/spf13/cobra"
 )
@@ -128,7 +129,7 @@ func connProfileDelCmd(cmd *cobra.Command, args []string) {
 func connProfileCmd() *cobra.Command {
 	cpCmd := &cobra.Command{
 		Use:   "conn",
-		Short: "Manage newtmgr connection profiles",
+		Short: "Manage " + nmutil.ToolInfo.ShortName + " connection profiles",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -136,14 +137,14 @@ func connProfileCmd() *cobra.Command {
 
 	addCmd := &cobra.Command{
 		Use:   "add <conn_profile> <varname=value ...> ",
-		Short: "Add a newtmgr connection profile",
+		Short: "Add a " + nmutil.ToolInfo.ShortName + " connection profile",
 		Run:   connProfileAddCmd,
 	}
 	cpCmd.AddCommand(addCmd)
 
 	deleCmd := &cobra.Command{
 		Use:   "delete <conn_profile>",
-		Short: "Delete a newtmgr connection profile",
+		Short: "Delete a " + nmutil.ToolInfo.ShortName + " connection profile",
 		Run:   connProfileDelCmd,
 	}
 	cpCmd.AddCommand(deleCmd)
@@ -154,7 +155,7 @@ func connProfileCmd() *cobra.Command {
 
 	showCmd := &cobra.Command{
 		Use:   "show [conn_profile]",
-		Short: "Show newtmgr connection profiles",
+		Short: "Show " + nmutil.ToolInfo.ShortName + " connection profiles",
 		Long:  connShowHelpText,
 		Run:   connProfileShowCmd,
 	}

--- a/newtmgr/cli/crash.go
+++ b/newtmgr/cli/crash.go
@@ -63,7 +63,7 @@ func crashRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func crashCmd() *cobra.Command {
-	crashEx := "   newtmgr -c olimex crash div0\n"
+	crashEx := "   " + nmutil.ToolInfo.ExeName + " -c olimex crash div0\n"
 
 	namesStr := strings.Join(xact.CrashTypeNames(), "|")
 	crashCmd := &cobra.Command{

--- a/newtmgr/cli/datetime.go
+++ b/newtmgr/cli/datetime.go
@@ -88,17 +88,22 @@ func dateTimeCmd() *cobra.Command {
 	dateTimeHelpText += "to set the datetime on the device.\n\n"
 	dateTimeHelpText += "Must specify datetime-value in RFC 3339 format.\n"
 
-	dateTimeEx := "newtmgr datetime -c myserial\n"
-	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00 -c myserial"
-	dateTimeEx += "             (implicit UTC) \n"
-	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00Z -c myserial"
-	dateTimeEx += "            (explicit UTC)\n"
-	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00-08:00 -c myserial"
-	dateTimeEx += "       (PST)\n"
-	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.1 -c myserial"
-	dateTimeEx += "           (fractional secs)\n"
-	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.101+05:30 -c myserial"
-	dateTimeEx += "   (fractional secs + timezone)\n"
+	dateTimeEx := nmutil.ToolInfo.ExeName + " datetime -c myserial\n"
+	dateTimeEx += nmutil.ToolInfo.ExeName +
+		" datetime 2016-03-02T22:44:00 -c myserial" +
+		"             (implicit UTC) \n"
+	dateTimeEx += nmutil.ToolInfo.ExeName +
+		" datetime 2016-03-02T22:44:00Z -c myserial" +
+		"            (explicit UTC)\n"
+	dateTimeEx += nmutil.ToolInfo.ExeName +
+		" datetime 2016-03-02T22:44:00-08:00 -c myserial" +
+		"       (PST)\n"
+	dateTimeEx += nmutil.ToolInfo.ExeName +
+		" datetime 2016-03-02T22:44:00.1 -c myserial" +
+		"           (fractional secs)\n"
+	dateTimeEx += nmutil.ToolInfo.ExeName +
+		" datetime 2016-03-02T22:44:00.101+05:30 -c myserial" +
+		"   (fractional secs + timezone)\n"
 
 	dateTimeCmd := &cobra.Command{
 		Use:     "datetime [rfc-3339-date-string] -c <conn_profile>",

--- a/newtmgr/cli/fs.go
+++ b/newtmgr/cli/fs.go
@@ -121,7 +121,8 @@ func fsCmd() *cobra.Command {
 		},
 	}
 
-	uploadEx := "  newtmgr -c olimex fs upload sample.lua /sample.lua\n"
+	uploadEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex fs upload sample.lua /sample.lua\n"
 
 	uploadCmd := &cobra.Command{
 		Use:     "upload <src-filename> <dst-filename> -c <conn_profile>",
@@ -131,7 +132,8 @@ func fsCmd() *cobra.Command {
 	}
 	fsCmd.AddCommand(uploadCmd)
 
-	downloadEx := "  newtmgr -c olimex image download /cfg/mfg mfg.txt\n"
+	downloadEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image download /cfg/mfg mfg.txt\n"
 
 	downloadCmd := &cobra.Command{
 		Use:     "download <src-filename> <dst-filename> -c <conn_profile>",

--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -383,8 +383,8 @@ func imageCmd() *cobra.Command {
 	}
 	imageCmd.AddCommand(confirmCmd)
 
-	uploadEx :=
-		"  newtmgr -c olimex image upload bin/slinky_zero/apps/slinky.img\n"
+	uploadEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image upload bin/slinky_zero/apps/slinky.img\n"
 
 	uploadCmd := &cobra.Command{
 		Use:     "upload <image-file> -c <conn_profile>",
@@ -400,13 +400,15 @@ func imageCmd() *cobra.Command {
 	coreListCmd := &cobra.Command{
 		Use:     "corelist -c <conn_profile>",
 		Short:   "List core(s) on a device",
-		Example: "  newtmgr -c olimex image corelist\n",
+		Example: "  " + nmutil.ToolInfo.ExeName + " -c olimex image corelist\n",
 		Run:     coreListCmd,
 	}
 	imageCmd.AddCommand(coreListCmd)
 
-	coreEx := "  newtmgr -c olimex image coredownload -e core\n"
-	coreEx += "  newtmgr -c olimex image coredownload --offset 10 -n 10 core\n"
+	coreEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image coredownload -e core\n"
+	coreEx += "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image coredownload --offset 10 -n 10 core\n"
 
 	coreDownloadCmd := &cobra.Command{
 		Use:     "coredownload <core-file> -c <conn_profile>",
@@ -421,7 +423,8 @@ func imageCmd() *cobra.Command {
 		"Number of bytes of the core to download")
 	imageCmd.AddCommand(coreDownloadCmd)
 
-	coreEraseEx := "  newtmgr -c olimex image coreerase\n"
+	coreEraseEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image coreerase\n"
 
 	coreEraseCmd := &cobra.Command{
 		Use:     "coreerase -c <conn_profile>",
@@ -435,7 +438,8 @@ func imageCmd() *cobra.Command {
 	imageEraseHelpText += "The image cannot be erased if the image is a confirmed image, is marked\n"
 	imageEraseHelpText += "for test on the next reboot, or is an active image for a split image setup.\n"
 
-	imageEraseEx := "  newtmgr -c olimex image erase\n"
+	imageEraseEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c olimex image erase\n"
 
 	imageEraseCmd := &cobra.Command{
 		Use:     "erase -c <conn_profile>",

--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -234,11 +234,11 @@ func logCmd() *cobra.Command {
 	logShowHelpText += "If \"last\"  is specified for min-index, the last\nlog entry is displayed.\n\n"
 	logShowHelpText += "- min-timestamp specifies to only display the log entries with a timestamp\nequal to or later than min-timestamp. Log entries with a timestamp equal to\nmin-timestamp are only displayed if the entry index is equal to or higher than min-index.\n"
 
-	logShowEx := "newtmgr log show -c myserial\n"
-	logShowEx += "newtmgr log show reboot_log -c myserial\n"
-	logShowEx += "newtmgr log show reboot_log last -c myserial\n"
-	logShowEx += "newtmgr log show reboot_log 5 -c myserial\n"
-	logShowEx += "newtmgr log show reboot_log 3 1122222 -c myserial\n"
+	logShowEx := nmutil.ToolInfo.ExeName + " log show -c myserial\n"
+	logShowEx += nmutil.ToolInfo.ExeName + " log show reboot_log -c myserial\n"
+	logShowEx += nmutil.ToolInfo.ExeName + " log show reboot_log last -c myserial\n"
+	logShowEx += nmutil.ToolInfo.ExeName + " log show reboot_log 5 -c myserial\n"
+	logShowEx += nmutil.ToolInfo.ExeName + " log show reboot_log 3 1122222 -c myserial\n"
 
 	showCmd := &cobra.Command{
 		Use:     "show [log-name [min-index [min-timestamp]]] -c <conn_profile>",

--- a/newtmgr/cli/run.go
+++ b/newtmgr/cli/run.go
@@ -98,7 +98,8 @@ func runCmd() *cobra.Command {
 		},
 	}
 
-	runtestEx := "  newtmgr -c conn run test all 201612161220"
+	runtestEx := "  " + nmutil.ToolInfo.ExeName +
+		" -c conn run test all 201612161220"
 
 	runTestHelpText := "Run tests on a device. Specify a testname to run a "
 	runTestHelpText += "specific test. All tests are\nrun if \"all\" or no "

--- a/newtmgr/config/connprofile.go
+++ b/newtmgr/config/connprofile.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 
 	"mynewt.apache.org/newt/util"
+	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 )
 
 type ConnProfileMgr struct {
@@ -125,7 +126,7 @@ func connProfileCfgFilename() (string, error) {
 		return "", util.NewNewtError(err.Error())
 	}
 
-	return dir + "/.newtmgr.cp.json", nil
+	return dir + nmutil.ToolInfo.CfgFilename, nil
 }
 
 func (cpm *ConnProfileMgr) Init() error {

--- a/newtmgr/newtmgr.go
+++ b/newtmgr/newtmgr.go
@@ -28,6 +28,7 @@ import (
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/cli"
 	"mynewt.apache.org/newtmgr/newtmgr/config"
+	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmserial"
 )
 
@@ -72,6 +73,14 @@ func cleanup() {
 }
 
 func main() {
+	nmutil.ToolInfo = nmutil.ToolInfoType{
+		ExeName:       "newtmgr",
+		ShortName:     "Newtmgr",
+		LongName:      "Apache Newtmgr",
+		VersionString: "1.4.0-dev",
+		CfgFilename:   ".newtmgr.cp.json",
+	}
+
 	if err := config.InitGlobalConnProfileMgr(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 		os.Exit(1)

--- a/newtmgr/nmutil/nmutil.go
+++ b/newtmgr/nmutil/nmutil.go
@@ -27,6 +27,14 @@ import (
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
 
+type ToolInfoType struct {
+	ExeName       string
+	ShortName     string
+	LongName      string
+	VersionString string
+	CfgFilename   string
+}
+
 var Timeout float64
 var Tries int
 var ConnProfile string
@@ -35,6 +43,7 @@ var BleWriteRsp bool
 var ConnType string
 var ConnString string
 var ConnExtra string
+var ToolInfo ToolInfoType
 
 func TxOptions() sesn.TxOptions {
 	return sesn.TxOptions{


### PR DESCRIPTION
This allows the tool name and version number to be changed at runtime.  This is required for other tools that want to depend on parts of newtmgr without pulling in confusing help messages.
    
The specific use case here is the mcumgr CLI tool.
