### PR TITLE
nmxact; default observe off when creating CoAP get command.

### DIFF
--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -111,7 +111,6 @@ func resGetCmd(cmd *cobra.Command, args []string) {
 	c := xact.NewGetResCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Path = path
-	c.Observe = -1
 	c.Typ = rt
 
 	res, err := c.Run(s)

--- a/nmxact/xact/res.go
+++ b/nmxact/xact/res.go
@@ -38,6 +38,7 @@ type GetResCmd struct {
 func NewGetResCmd() *GetResCmd {
 	return &GetResCmd{
 		CmdBase: NewCmdBase(),
+		Observe: -1,
 	}
 }
 


### PR DESCRIPTION
So users of nmxact library don't need to modify their code to set Observe to -1 to prevent it from happening.