### PR TITLE
Remove hardcoded "newtmgr" strings.

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -37,7 +37,7 @@ func Commands() *cobra.Command {
 	logLevelStr := ""
 	nmCmd := &cobra.Command{
 		Use:   nmutil.ToolInfo.ExeName,
-		Short: nmutil.ToolInfo.ShortName + " helps you manage remote devices running the Mynewt OS",
+		Short: nmutil.ToolInfo.ShortName + " helps you manage remote devices",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			NewtmgrLogLevel, err := log.ParseLevel(logLevelStr)
 			if err != nil {

--- a/newtmgr/cli/interactive.go
+++ b/newtmgr/cli/interactive.go
@@ -3,9 +3,9 @@ package cli
 import (
 	"container/list"
 	"fmt"
-	"gopkg.in/abiosoft/ishell.v1"
 	"github.com/runtimeco/go-coap"
 	"github.com/spf13/cobra"
+	"gopkg.in/abiosoft/ishell.v1"
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
@@ -508,9 +508,10 @@ func startInteractive(cmd *cobra.Command, args []string) {
 func interactiveCmd() *cobra.Command {
 
 	shellCmd := &cobra.Command{
-		Use:   "interactive",
-		Short: "Run newtmgr interactive mode (used for COAP only)",
-		Run:   startInteractive,
+		Use: "interactive",
+		Short: "Run " + nmutil.ToolInfo.ShortName +
+			" interactive mode (used for COAP only)",
+		Run: startInteractive,
 	}
 
 	return shellCmd


### PR DESCRIPTION
The newtmgr codebase is used in two tools:
    * newtmgr
    * mcumgr

An earlier commit (a895655ebc82d0c57c15ae29eea68536c10b8a70) allowed the
application to configure its own name for displaying help messages
properly.  A few instances of "newtmgr" were missed in that commit.
This commit catches the remaining instances.