### PR TITLE
bll - Allow OwnAddrType to be specified in linux.

### DIFF
--- a/newtmgr/bll/bll_xport.go
+++ b/newtmgr/bll/bll_xport.go
@@ -27,11 +27,13 @@ import (
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/examples/lib/dev"
 
+	"mynewt.apache.org/newtmgr/nmxact/bledefs"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
 
 type XportCfg struct {
-	CtlrName string
+	CtlrName    string
+	OwnAddrType bledefs.BleAddrType
 }
 
 func NewXportCfg() XportCfg {
@@ -62,6 +64,11 @@ func (bx *BllXport) BuildBllSesn(cfg BllSesnCfg) (sesn.Sesn, error) {
 func (bx *BllXport) Start() error {
 	d, err := dev.NewDevice(bx.cfg.CtlrName)
 	if err != nil {
+		return err
+	}
+
+	// Set the connection parameters to use for all initiated connections.
+	if err := BllXportSetConnParams(d, bx.cfg.OwnAddrType); err != nil {
 		return err
 	}
 

--- a/newtmgr/bll/bll_xport_linux.go
+++ b/newtmgr/bll/bll_xport_linux.go
@@ -1,0 +1,61 @@
+// +build linux
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package bll
+
+import (
+	"github.com/go-ble/ble"
+	"github.com/go-ble/ble/linux"
+	"github.com/go-ble/ble/linux/hci"
+	"github.com/go-ble/ble/linux/hci/cmd"
+
+	"mynewt.apache.org/newt/util"
+	"mynewt.apache.org/newtmgr/nmxact/bledefs"
+)
+
+func BllXportSetConnParams(dev ble.Device, ownAddrType bledefs.BleAddrType) error {
+	ldev := dev.(*linux.Device)
+
+	cc := cmd.LECreateConnection{
+		LEScanInterval:        0x0010, // 0x0004 - 0x4000; N * 0.625 msec
+		LEScanWindow:          0x0010, // 0x0004 - 0x4000; N * 0.625 msec
+		InitiatorFilterPolicy: 0x00,   // White list is not used
+		OwnAddressType:        uint8(ownAddrType),
+		ConnIntervalMin:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
+		ConnIntervalMax:       0x0006, // 0x0006 - 0x0C80; N * 1.25 msec
+		ConnLatency:           0x0000, // 0x0000 - 0x01F3; N * 1.25 msec
+		SupervisionTimeout:    0x0048, // 0x000A - 0x0C80; N * 10 msec
+		MinimumCELength:       0x0000, // 0x0000 - 0xFFFF; N * 0.625 msec
+		MaximumCELength:       0x0000, // 0x0000 - 0xFFFF; N * 0.625 msec
+
+		// Specified at connect time.
+		PeerAddressType: 0x00,      // Public Device Address
+		PeerAddress:     [6]byte{}, //
+	}
+
+	opt := hci.OptConnParams(cc)
+	if err := ldev.HCI.Option(opt); err != nil {
+		return util.FmtNewtError("error setting connection parameters: %s",
+			err.Error())
+	}
+
+	return nil
+}

--- a/newtmgr/bll/bll_xport_nonlinux.go
+++ b/newtmgr/bll/bll_xport_nonlinux.go
@@ -1,0 +1,34 @@
+// +build !linux
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package bll
+
+import (
+	"github.com/go-ble/ble"
+
+	"mynewt.apache.org/newtmgr/nmxact/bledefs"
+)
+
+// macOS (CoreBluetooth) does not allow the connection parameters to be
+// configured, so this function is a no-op.
+func BllXportSetConnParams(dev ble.Device, ownAddrType bledefs.BleAddrType) error {
+	return nil
+}

--- a/newtmgr/cli/common.go
+++ b/newtmgr/cli/common.go
@@ -130,6 +130,7 @@ func GetXport() (xport.Xport, error) {
 		if bc.CtlrName != "" {
 			cfg.CtlrName = bc.CtlrName
 		}
+		cfg.OwnAddrType = bc.OwnAddrType
 		globalXport = bll.NewBllXport(cfg)
 
 	case config.CONN_TYPE_BLE_PLAIN, config.CONN_TYPE_BLE_OIC:

--- a/newtmgr/config/bll_config.go
+++ b/newtmgr/config/bll_config.go
@@ -30,12 +30,14 @@ import (
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/bll"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
+	"mynewt.apache.org/newtmgr/nmxact/bledefs"
 )
 
 type BllConfig struct {
-	CtlrName string
-	PeerId   string
-	PeerName string
+	CtlrName    string
+	OwnAddrType bledefs.BleAddrType
+	PeerId      string
+	PeerName    string
 }
 
 func NewBllConfig() *BllConfig {
@@ -68,6 +70,12 @@ func ParseBllConnString(cs string) (*BllConfig, error) {
 		switch k {
 		case "ctlr_name":
 			bc.CtlrName = v
+		case "own_addr_type":
+			var err error
+			bc.OwnAddrType, err = bledefs.BleAddrTypeFromString(v)
+			if err != nil {
+				return nil, einvalBleConnString("Invalid own_addr_type: %s", v)
+			}
 		case "peer_id":
 			bc.PeerId = v
 		case "peer_name":


### PR DESCRIPTION
Prior to this commit, newtmgr always used a public address to connect.

This commit makes two changes (Linux only):
* allows the user to specify own address type with the `own_addr_type` connection setting.
* uses a value of 0x10 (10 ms) for the scan interval and scan window (was: 2.5 ms for both).

These changes only have an effect in Linux.  In macOS, the CoreBluetooth library does not allow these settings to be specified at connect time.