### PR TITLE
Filter newtmgr CoAP messages

### DIFF
--- a/newtmgr/bll/bll_sesn.go
+++ b/newtmgr/bll/bll_sesn.go
@@ -35,6 +35,7 @@ import (
 	"mynewt.apache.org/newtmgr/nmxact/bledefs"
 	"mynewt.apache.org/newtmgr/nmxact/mgmt"
 	"mynewt.apache.org/newtmgr/nmxact/nmble"
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
@@ -59,11 +60,16 @@ type BllSesn struct {
 	unauthRspChr *ble.Characteristic
 	secureReqChr *ble.Characteristic
 	secureRspChr *ble.Characteristic
+
+	txFilterCb nmcoap.MsgFilter
+	rxFilterCb nmcoap.MsgFilter
 }
 
 func NewBllSesn(cfg BllSesnCfg) *BllSesn {
 	return &BllSesn{
-		cfg: cfg,
+		cfg:        cfg,
+		txFilterCb: cfg.TxFilterCb,
+		rxFilterCb: cfg.RxFilterCb,
 	}
 }
 
@@ -294,7 +300,7 @@ func (s *BllSesn) openOnce() (bool, error) {
 			"Attempt to open an already-open bll session")
 	}
 
-	txvr, err := mgmt.NewTransceiver(true, s.cfg.MgmtProto, 3)
+	txvr, err := mgmt.NewTransceiver(s.txFilterCb, s.rxFilterCb, true, s.cfg.MgmtProto, 3)
 	if err != nil {
 		return false, err
 	}
@@ -468,4 +474,8 @@ func (s *BllSesn) MgmtProto() sesn.MgmtProto {
 
 func (s *BllSesn) CoapIsTcp() bool {
 	return true
+}
+
+func (s *BllSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+	return s.txFilterCb, s.rxFilterCb
 }

--- a/newtmgr/bll/bll_sesn_cfg.go
+++ b/newtmgr/bll/bll_sesn_cfg.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-ble/ble"
 
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
 
@@ -36,6 +37,8 @@ type BllSesnCfg struct {
 	ConnTimeout  time.Duration
 	ConnTries    int
 	WriteRsp     bool
+	TxFilterCb   nmcoap.MsgFilter
+	RxFilterCb   nmcoap.MsgFilter
 }
 
 func NewBllSesnCfg() BllSesnCfg {

--- a/nmxact/mgmt/mgmt.go
+++ b/nmxact/mgmt/mgmt.go
@@ -33,10 +33,11 @@ func EncodeMgmt(s sesn.Sesn, m *nmp.NmpMsg) ([]byte, error) {
 		return nmp.EncodeNmpPlain(m)
 
 	case sesn.MGMT_PROTO_OMP:
+		txCb, _ := s.Filters()
 		if s.CoapIsTcp() == true {
-			return omp.EncodeOmpTcp(m)
+			return omp.EncodeOmpTcp(txCb, m)
 		} else {
-			return omp.EncodeOmpDgram(m)
+			return omp.EncodeOmpDgram(txCb, m)
 		}
 
 	default:

--- a/nmxact/nmble/ble_sesn.go
+++ b/nmxact/nmble/ble_sesn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/runtimeco/go-coap"
 
 	. "mynewt.apache.org/newtmgr/nmxact/bledefs"
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
@@ -119,4 +120,8 @@ func (s *BleSesn) TxCoapObserve(m coap.Message,
 	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
 
 	return s.Ns.TxCoapObserve(m, resType, opt, NotifCb, stopsignal)
+}
+
+func (s *BleSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+	return s.Ns.Filters()
 }

--- a/nmxact/nmcoap/nmcoap.go
+++ b/nmxact/nmcoap/nmcoap.go
@@ -21,11 +21,13 @@ package nmcoap
 
 import (
 	"fmt"
-
-	"github.com/runtimeco/go-coap"
 	"strings"
 	"sync"
+
+	"github.com/runtimeco/go-coap"
 )
+
+type MsgFilter func(msg coap.Message) (coap.Message, error)
 
 var messageIdMtx sync.Mutex
 var nextMessageId uint16

--- a/nmxact/sesn/sesn.go
+++ b/nmxact/sesn/sesn.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/runtimeco/go-coap"
 
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 )
 
@@ -104,4 +105,7 @@ type Sesn interface {
 
 	TxCoapObserve(m coap.Message, resType ResourceType,
 		opt TxOptions, NotifCb GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error)
+
+	// Returns a transmit and a receive callback used to manipulate CoAP messages
+	Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter)
 }

--- a/nmxact/sesn/sesn_cfg.go
+++ b/nmxact/sesn/sesn_cfg.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"mynewt.apache.org/newtmgr/nmxact/bledefs"
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 )
 
 type MgmtProto int
@@ -100,6 +101,10 @@ type SesnCfg struct {
 	// Transport-specific configuration.
 	Ble  SesnCfgBle
 	Lora SesnCfgLora
+
+	// Callbacks
+	TxFilterCb nmcoap.MsgFilter
+	RxFilterCb nmcoap.MsgFilter
 }
 
 func NewSesnCfg() SesnCfg {

--- a/nmxact/udp/udp_sesn.go
+++ b/nmxact/udp/udp_sesn.go
@@ -26,6 +26,7 @@ import (
 	"github.com/runtimeco/go-coap"
 
 	"mynewt.apache.org/newtmgr/nmxact/mgmt"
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 	"mynewt.apache.org/newtmgr/nmxact/omp"
@@ -37,13 +38,18 @@ type UdpSesn struct {
 	addr *net.UDPAddr
 	conn *net.UDPConn
 	txvr *mgmt.Transceiver
+
+	txFilterCb nmcoap.MsgFilter
+	rxFilterCb nmcoap.MsgFilter
 }
 
 func NewUdpSesn(cfg sesn.SesnCfg) (*UdpSesn, error) {
 	s := &UdpSesn{
-		cfg: cfg,
+		cfg:        cfg,
+		txFilterCb: cfg.TxFilterCb,
+		rxFilterCb: cfg.RxFilterCb,
 	}
-	txvr, err := mgmt.NewTransceiver(false, cfg.MgmtProto, 3)
+	txvr, err := mgmt.NewTransceiver(cfg.TxFilterCb, cfg.RxFilterCb, false, cfg.MgmtProto, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -162,4 +168,8 @@ func (s *UdpSesn) TxCoapObserve(m coap.Message, resType sesn.ResourceType,
 
 func (s *UdpSesn) CoapIsTcp() bool {
 	return false
+}
+
+func (s *UdpSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+	return s.txFilterCb, s.rxFilterCb
 }


### PR DESCRIPTION
Support setting a transmit and receive callback for newtmgr CoAP
messages. This enables filtering the messages to do encryption, logging,
metrics, etc. The TxFilterCb and RxFilterCb are set in SesnCfg.