### PR TITLE
Use custom type for LogEntryType (was: string)

### DIFF
--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -92,7 +92,7 @@ func logShowCmd(cmd *cobra.Command, args []string) {
 		fmt.Printf("%10s %22s | %11s %11s %6s %s\n",
 			"[index]", "[timestamp]", "[module]", "[level]", "[type]", "[message]")
 		for _, entry := range log.Entries {
-			fmt.Printf("%10d %20dus | %10s: %10s: %5s: %s\n",
+			fmt.Printf("%10d %20dus | %11s %11s %6s %s\n",
 				entry.Index,
 				entry.Timestamp,
 				nmp.LogModuleToString(int(entry.Module)),

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -132,12 +132,12 @@ type LogShowReq struct {
 }
 
 type LogEntry struct {
-	Index     uint32 `codec:"index"`
-	Timestamp int64  `codec:"ts"`
-	Module    uint8  `codec:"module"`
-	Level     uint8  `codec:"level"`
-	Type      string `codec:"type"`
-	Msg       []byte `codec:"msg"`
+	Index     uint32       `codec:"index"`
+	Timestamp int64        `codec:"ts"`
+	Module    uint8        `codec:"module"`
+	Level     uint8        `codec:"level"`
+	Type      LogEntryType `codec:"type"`
+	Msg       []byte       `codec:"msg"`
 }
 
 type LogShowLog struct {
@@ -299,6 +299,10 @@ func LogEntryTypeFromString(s string) (LogEntryType, error) {
 	}
 
 	return LogEntryType(0), fmt.Errorf("Invalid LogEntryType string: %s", s)
+}
+
+func (l LogEntryType) String() string {
+	return LogEntryTypeToString(l)
 }
 
 func (l LogEntryType) MarshalBinary([]byte, error) error {


### PR DESCRIPTION
This enables the custom type's marshal and unmarshal functions.