### PR TITLE
nmxact: Add data hash to 1st chunk of image upload data

### DIFF
--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -27,9 +27,10 @@ import ()
 
 type ImageUploadReq struct {
 	NmpBase
-	Off  uint32 `codec:"off"`
-	Len  uint32 `codec:"len" codec:",omitempty"`
-	Data []byte `codec:"data"`
+	Off      uint32 `codec:"off"`
+	Len      uint32 `codec:"len" codec:",omitempty"`
+	DataHash []byte `codec:"datahash" codec:",omitempty"`
+	Data     []byte `codec:"data"`
 }
 
 type ImageUploadRsp struct {


### PR DESCRIPTION
When uploading image, 1st chunk will include "datahash" field which is
simply SHA-256 calculated over complete data to be uploaded (so it is
not the same as image hash). This field can be then used by imgmgr on
target to detect whether the same data is being uploaded and possibly
resume transfer which was interrupted previously.