### PR TITLE
Fixes in NMP encoding code

### DIFF
--- a/nmxact/nmp/config.go
+++ b/nmxact/nmp/config.go
@@ -32,7 +32,7 @@ type ConfigReadReq struct {
 
 type ConfigReadRsp struct {
 	NmpBase
-	Rc  int    `codec:"rc" codec:",omitempty"`
+	Rc  int    `codec:"rc"`
 	Val string `codec:"val"`
 }
 
@@ -63,7 +63,7 @@ type ConfigWriteReq struct {
 
 type ConfigWriteRsp struct {
 	NmpBase
-	Rc int `codec:"rc" codec:",omitempty"`
+	Rc int `codec:"rc"`
 }
 
 func NewConfigWriteReq() *ConfigWriteReq {

--- a/nmxact/nmp/config.go
+++ b/nmxact/nmp/config.go
@@ -26,7 +26,7 @@ import ()
 //////////////////////////////////////////////////////////////////////////////
 
 type ConfigReadReq struct {
-	NmpBase `structs:"-"`
+	NmpBase        `codec:"-"`
 	Name    string `codec:"name"`
 }
 
@@ -55,10 +55,10 @@ func (r *ConfigReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type ConfigWriteReq struct {
-	NmpBase
-	Name string `codec:"name",omitempty`
-	Val  string `codec:"val",omitempty`
-	Save bool   `codec:"save",omitempty`
+	NmpBase     `codec:"-"`
+	Name string `codec:"name,omitempty"`
+	Val  string `codec:"val,omitempty"`
+	Save bool   `codec:"save,omitempty"`
 }
 
 type ConfigWriteRsp struct {

--- a/nmxact/nmp/crash.go
+++ b/nmxact/nmp/crash.go
@@ -28,7 +28,7 @@ type CrashReq struct {
 
 type CrashRsp struct {
 	NmpBase
-	Rc int `codec:"rc" codec:",omitempty"`
+	Rc int `codec:"rc"`
 }
 
 func NewCrashReq() *CrashReq {

--- a/nmxact/nmp/crash.go
+++ b/nmxact/nmp/crash.go
@@ -22,7 +22,7 @@ package nmp
 import ()
 
 type CrashReq struct {
-	NmpBase
+	NmpBase          `codec:"-"`
 	CrashType string `codec:"t"`
 }
 

--- a/nmxact/nmp/datetime.go
+++ b/nmxact/nmp/datetime.go
@@ -26,7 +26,7 @@ import ()
 ///////////////////////////////////////////////////////////////////////////////
 
 type DateTimeReadReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type DateTimeReadRsp struct {
@@ -54,7 +54,7 @@ func (r *DateTimeReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 ///////////////////////////////////////////////////////////////////////////////
 
 type DateTimeWriteReq struct {
-	NmpBase
+	NmpBase         `codec:"-"`
 	DateTime string `codec:"datetime"`
 }
 

--- a/nmxact/nmp/datetime.go
+++ b/nmxact/nmp/datetime.go
@@ -32,7 +32,7 @@ type DateTimeReadReq struct {
 type DateTimeReadRsp struct {
 	NmpBase
 	DateTime string `codec:"datetime"`
-	Rc       int    `codec:"rc" codec:",omitempty"`
+	Rc       int    `codec:"rc"`
 }
 
 func NewDateTimeReadReq() *DateTimeReadReq {
@@ -60,7 +60,7 @@ type DateTimeWriteReq struct {
 
 type DateTimeWriteRsp struct {
 	NmpBase
-	Rc int `codec:"rc" codec:",omitempty"`
+	Rc int `codec:"rc"`
 }
 
 func NewDateTimeWriteReq() *DateTimeWriteReq {

--- a/nmxact/nmp/echo.go
+++ b/nmxact/nmp/echo.go
@@ -22,7 +22,7 @@ package nmp
 import ()
 
 type EchoReq struct {
-	NmpBase
+	NmpBase        `codec:"-"`
 	Payload string `codec:"d"`
 }
 

--- a/nmxact/nmp/echo.go
+++ b/nmxact/nmp/echo.go
@@ -29,7 +29,7 @@ type EchoReq struct {
 type EchoRsp struct {
 	NmpBase
 	Payload string `codec:"r"`
-	Rc      int    `codec:"rc" codec:",omitempty"`
+	Rc      int    `codec:"rc"`
 }
 
 func NewEchoReq() *EchoReq {

--- a/nmxact/nmp/fs.go
+++ b/nmxact/nmp/fs.go
@@ -33,7 +33,7 @@ type FsDownloadReq struct {
 
 type FsDownloadRsp struct {
 	NmpBase
-	Rc   int    `codec:"rc" codec:",omitempty"`
+	Rc   int    `codec:"rc"`
 	Off  uint32 `codec:"off"`
 	Len  uint32 `codec:"len"`
 	Data []byte `codec:"data"`
@@ -67,7 +67,7 @@ type FsUploadReq struct {
 
 type FsUploadRsp struct {
 	NmpBase
-	Rc  int    `codec:"rc" codec:",omitempty"`
+	Rc  int    `codec:"rc"`
 	Off uint32 `codec:"off"`
 }
 

--- a/nmxact/nmp/fs.go
+++ b/nmxact/nmp/fs.go
@@ -26,7 +26,7 @@ import ()
 //////////////////////////////////////////////////////////////////////////////
 
 type FsDownloadReq struct {
-	NmpBase
+	NmpBase     `codec:"-"`
 	Name string `codec:"name"`
 	Off  uint32 `codec:"off"`
 }
@@ -58,9 +58,9 @@ func (r *FsDownloadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type FsUploadReq struct {
-	NmpBase
-	Name string `codec:"name" codec:",omitempty"`
-	Len  uint32 `codec:"len" codec:",omitempty"`
+	NmpBase     `codec:"-"`
+	Name string `codec:"name,omitempty"`
+	Len  uint32 `codec:"len,omitempty"`
 	Off  uint32 `codec:"off"`
 	Data []byte `codec:"data"`
 }

--- a/nmxact/nmp/fs.go
+++ b/nmxact/nmp/fs.go
@@ -59,8 +59,8 @@ func (r *FsDownloadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 type FsUploadReq struct {
 	NmpBase     `codec:"-"`
-	Name string `codec:"name,omitempty"`
-	Len  uint32 `codec:"len,omitempty"`
+	Name string `codec:"name"`
+	Len  uint32 `codec:"len"`
 	Off  uint32 `codec:"off"`
 	Data []byte `codec:"data"`
 }

--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -35,7 +35,7 @@ type ImageUploadReq struct {
 
 type ImageUploadRsp struct {
 	NmpBase
-	Rc  int    `codec:"rc" codec:",omitempty"`
+	Rc  int    `codec:"rc"`
 	Off uint32 `codec:"off"`
 }
 

--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -26,10 +26,10 @@ import ()
 //////////////////////////////////////////////////////////////////////////////
 
 type ImageUploadReq struct {
-	NmpBase
+	NmpBase         `codec:"-"`
 	Off      uint32 `codec:"off"`
-	Len      uint32 `codec:"len" codec:",omitempty"`
-	DataHash []byte `codec:"datahash" codec:",omitempty"`
+	Len      uint32 `codec:"len,omitempty"`
+	DataHash []byte `codec:"datahash,omitempty"`
 	Data     []byte `codec:"data"`
 }
 
@@ -93,11 +93,11 @@ type ImageStateEntry struct {
 }
 
 type ImageStateReadReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type ImageStateWriteReq struct {
-	NmpBase
+	NmpBase        `codec:"-"`
 	Hash    []byte `codec:"hash"`
 	Confirm bool   `codec:"confirm"`
 }
@@ -136,7 +136,7 @@ func (r *ImageStateRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type CoreListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type CoreListRsp struct {
@@ -163,7 +163,7 @@ func (r *CoreListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type CoreLoadReq struct {
-	NmpBase
+	NmpBase    `codec:"-"`
 	Off uint32 `codec:"off"`
 }
 
@@ -194,7 +194,7 @@ func (r *CoreLoadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type CoreEraseReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type CoreEraseRsp struct {
@@ -221,7 +221,7 @@ func (r *CoreEraseRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type ImageEraseReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type ImageEraseRsp struct {

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -125,7 +125,7 @@ var LogEntryTypeStringMap = map[LogEntryType]string{
 }
 
 type LogShowReq struct {
-	NmpBase
+	NmpBase          `codec:"-"`
 	Name      string `codec:"log_name"`
 	Timestamp int64  `codec:"ts"`
 	Index     uint32 `codec:"index"`
@@ -172,7 +172,7 @@ func (r *LogShowRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type LogListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type LogListRsp struct {
@@ -200,7 +200,7 @@ func (r *LogListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type LogModuleListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type LogModuleListRsp struct {
@@ -228,7 +228,7 @@ func (r *LogModuleListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type LogLevelListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type LogLevelListRsp struct {
@@ -256,7 +256,7 @@ func (r *LogLevelListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type LogClearReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type LogClearRsp struct {

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -177,7 +177,7 @@ type LogListReq struct {
 
 type LogListRsp struct {
 	NmpBase
-	Rc   int      `codec:"rc" codec:",omitempty"`
+	Rc   int      `codec:"rc"`
 	List []string `codec:"log_list"`
 }
 
@@ -205,7 +205,7 @@ type LogModuleListReq struct {
 
 type LogModuleListRsp struct {
 	NmpBase
-	Rc  int            `codec:"rc" codec:",omitempty"`
+	Rc  int            `codec:"rc"`
 	Map map[string]int `codec:"module_map"`
 }
 
@@ -233,7 +233,7 @@ type LogLevelListReq struct {
 
 type LogLevelListRsp struct {
 	NmpBase
-	Rc  int            `codec:"rc" codec:",omitempty"`
+	Rc  int            `codec:"rc"`
 	Map map[string]int `codec:"level_map"`
 }
 
@@ -261,7 +261,7 @@ type LogClearReq struct {
 
 type LogClearRsp struct {
 	NmpBase
-	Rc int `codec:"rc" codec:",omitempty"`
+	Rc int `codec:"rc"`
 }
 
 func NewLogClearReq() *LogClearReq {

--- a/nmxact/nmp/mpstat.go
+++ b/nmxact/nmp/mpstat.go
@@ -22,7 +22,7 @@ package nmp
 import ()
 
 type MempoolStatReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type MempoolStatRsp struct {

--- a/nmxact/nmp/reset.go
+++ b/nmxact/nmp/reset.go
@@ -22,7 +22,7 @@ package nmp
 import ()
 
 type ResetReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type ResetRsp struct {

--- a/nmxact/nmp/run.go
+++ b/nmxact/nmp/run.go
@@ -26,7 +26,7 @@ import ()
 //////////////////////////////////////////////////////////////////////////////
 
 type RunTestReq struct {
-	NmpBase
+	NmpBase         `codec:"-"`
 	Testname string `codec:"testname"`
 	Token    string `codec:"token"`
 }
@@ -55,7 +55,7 @@ func (r *RunTestRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type RunListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type RunListRsp struct {

--- a/nmxact/nmp/run.go
+++ b/nmxact/nmp/run.go
@@ -33,7 +33,7 @@ type RunTestReq struct {
 
 type RunTestRsp struct {
 	NmpBase
-	Rc int `codec:"rc" codec:",omitempty"`
+	Rc int `codec:"rc"`
 }
 
 func NewRunTestReq() *RunTestReq {
@@ -60,7 +60,7 @@ type RunListReq struct {
 
 type RunListRsp struct {
 	NmpBase
-	Rc   int      `codec:"rc" codec:",omitempty"`
+	Rc   int      `codec:"rc"`
 	List []string `codec:"run_list"`
 }
 

--- a/nmxact/nmp/stat.go
+++ b/nmxact/nmp/stat.go
@@ -26,7 +26,7 @@ import ()
 //////////////////////////////////////////////////////////////////////////////
 
 type StatReadReq struct {
-	NmpBase
+	NmpBase     `codec:"-"`
 	Name string `codec:"name"`
 }
 
@@ -57,7 +57,7 @@ func (r *StatReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type StatListReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type StatListRsp struct {

--- a/nmxact/nmp/taskstat.go
+++ b/nmxact/nmp/taskstat.go
@@ -27,7 +27,7 @@ type TaskStatReq struct {
 
 type TaskStatRsp struct {
 	NmpBase
-	Rc    int                       `codec:"rc" codec:",omitempty"`
+	Rc    int                       `codec:"rc"`
 	Tasks map[string]map[string]int `codec:"tasks"`
 }
 

--- a/nmxact/nmp/taskstat.go
+++ b/nmxact/nmp/taskstat.go
@@ -22,7 +22,7 @@ package nmp
 import ()
 
 type TaskStatReq struct {
-	NmpBase
+	NmpBase `codec:"-"`
 }
 
 type TaskStatRsp struct {

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -120,13 +120,10 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 	payload := []byte{}
 	enc := codec.NewEncoderBytes(&payload, new(codec.CborHandle))
 
-	fields := structs.Fields(nmr.Body)
-	er.fieldMap = make(map[string]interface{}, len(fields))
-	for _, f := range fields {
-		if cname := f.Tag("codec"); cname != "" {
-			er.fieldMap[cname] = f.Value()
-		}
-	}
+	// Convert request struct to map, use "codec" tag which is compatible with "structs"
+	s := structs.New(nmr.Body)
+	s.TagName = "codec"
+	er.fieldMap = s.Map()
 
 	// Add the NMP heder to the OMP response map.
 	er.hdrBytes = nmr.Hdr.Bytes()

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -125,7 +125,7 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 	s.TagName = "codec"
 	er.fieldMap = s.Map()
 
-	// Add the NMP heder to the OMP response map.
+	// Add the NMP header to the OMP response map.
 	er.hdrBytes = nmr.Hdr.Bytes()
 	er.fieldMap["_h"] = er.hdrBytes
 

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -70,7 +70,7 @@ func buildImageUploadReq(imageSz int, hash []byte, chunk []byte,
 
 	r := nmp.NewImageUploadReq()
 
-	if r.Off == 0 {
+	if off == 0 {
 		r.Len = uint32(imageSz)
 		r.DataHash = hash
 	}


### PR DESCRIPTION
The main issue fixed here is that when using NMP over OIC empty fields in requests were not skipped properly since this should be done automatically with `omitempty` option in `codec` tag, but this tag was in fact ignored during encoding. This is now fixed by using small trick with structs package.

Also, due to invalid check, `image upload` always included `len` and `datahash` fields in every chunk of data and this is now also fixed so some bytes are saved over the air.

Tested using few commands via `ble` and `oic_ble` connection types.