### PR TITLE
nmxact: Make field name for uploaded data hash shorter

### DIFF
--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -29,7 +29,7 @@ type ImageUploadReq struct {
 	NmpBase         `codec:"-"`
 	Off      uint32 `codec:"off"`
 	Len      uint32 `codec:"len,omitempty"`
-	DataHash []byte `codec:"datahash,omitempty"`
+	DataSha  []byte `codec:"sha,omitempty"`
 	Data     []byte `codec:"data"`
 }
 

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -73,7 +73,7 @@ func buildImageUploadReq(imageSz int, hash []byte, chunk []byte,
 
 	if off == 0 {
 		r.Len = uint32(imageSz)
-		r.DataHash = hash
+		r.DataSha = hash
 	}
 	r.Off = uint32(off)
 	r.Data = chunk


### PR DESCRIPTION
Let's use "sha" instead of "datahash" to keep it short.
Long name like "datahash" not only adds few unnecessary bytes to data
stream but also makes image upload fail with MCUBoot which does not
handle long key names (no need to change it there though).

"sha" name was chosen as it is short and should not be confused with
image hash which is something different since data hash is computed
over whole upload data, i.e. image with trailing data etc.).

This fixes https://github.com/apache/mynewt-mcumgr-cli/issues/2.