### PR TITLE
Allow "conn_timeout" for ble and bll types.

### DIFF
--- a/newtmgr/config/ble_config.go
+++ b/newtmgr/config/ble_config.go
@@ -40,6 +40,9 @@ type BleConfig struct {
 	OwnAddrType bledefs.BleAddrType
 	OwnAddr     bledefs.BleAddr
 
+	// Connection timeout, in seconds.
+	ConnTimeout float64
+
 	BlehostdPath   string
 	ControllerPath string
 }
@@ -47,6 +50,7 @@ type BleConfig struct {
 func NewBleConfig() *BleConfig {
 	return &BleConfig{
 		OwnAddrType:  bledefs.BLE_ADDR_TYPE_RANDOM,
+		ConnTimeout:  nmutil.Timeout,
 		BlehostdPath: "blehostd",
 	}
 }
@@ -138,7 +142,8 @@ func FillSesnCfg(bx *nmble.BleXport, bc *BleConfig, sc *sesn.SesnCfg) error {
 		}
 	}
 
-	// We don't need to stick around until a connection closes.
+	sc.Ble.Central.ConnTimeout =
+		time.Duration(bc.ConnTimeout*1000000000) * time.Nanosecond
 	sc.Ble.CloseTimeout = 10000 * time.Millisecond
 
 	sc.Ble.WriteRsp = nmutil.BleWriteRsp


### PR DESCRIPTION
This specifies the connection timeout, in seconds.  E.g.,
```
newtmgr --conntype ble --connstring peer_name=mydev,conn_timeout=23.54' -t 4 echo a
```

This command allows 23.54 seconds for the BLE connection to be established.  Upon sending the echo request, newtmgr waits four seconds before reporting a response timeout.

In addition, if the `conn_timeout` setting is not specified, it defaults to the response timeout value (`-t`).