### PR TITLE
Fix [un]marshal of log-entry-type

### DIFF
--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -21,8 +21,6 @@ package nmp
 
 import (
 	"fmt"
-
-	"github.com/ugorji/go/codec"
 )
 
 //////////////////////////////////////////////////////////////////////////////
@@ -125,7 +123,7 @@ var LogEntryTypeStringMap = map[LogEntryType]string{
 }
 
 type LogShowReq struct {
-	NmpBase          `codec:"-"`
+	NmpBase   `codec:"-"`
 	Name      string `codec:"log_name"`
 	Timestamp int64  `codec:"ts"`
 	Index     uint32 `codec:"index"`
@@ -305,37 +303,17 @@ func (l LogEntryType) String() string {
 	return LogEntryTypeToString(l)
 }
 
-func (l LogEntryType) MarshalBinary([]byte, error) error {
-	var err error
-	var s string
-	var b []byte
-
-	handle := new(codec.CborHandle)
-
-	s = LogEntryTypeToString(l)
-
-	dec := codec.NewEncoderBytes(&b, handle)
-
-	err = dec.Encode(&b)
-	if err != nil {
-		return err
-	}
-
-	b = append(b, s...)
-
-	return err
+func (l LogEntryType) MarshalBinary() ([]byte, error) {
+	return []byte(l.String()), nil
 }
 
 func (l *LogEntryType) UnmarshalBinary(data []byte) error {
 	var err error
-	var s string
 
-	handle := new(codec.CborHandle)
-	dec := codec.NewDecoderBytes(data, handle)
+	*l, err = LogEntryTypeFromString(string(data))
+	if err != nil {
+		return err
+	}
 
-	err = dec.Decode(&s)
-
-	*l, err = LogEntryTypeFromString(s)
-
-	return err
+	return nil
 }


### PR DESCRIPTION
This PR fixes a bug where newtmgr could not retrieve logs from a device using a `LOG_VERSION` of 3:
```
[ccollins@ccollins-mac:~/repos/juul-platform]$ newtmgr -ldebug --conntype oic_ble --connstring peer_name=cc log show
DEBU[2018-07-10 10:41:47.863] Using connection profile: name=unnamed type=oic_ble connstring=peer_name=cc
DEBU[2018-07-10 10:41:47.864] {add-oic-listener} [transceiver.go:64] token=[]
DEBU[2018-07-10 10:41:47.864] Connecting to peer
DEBU[2018-07-10 10:41:48.514] Exchanging MTU
DEBU[2018-07-10 10:41:48.514] Exchanged MTU; ATT MTU = 104
DEBU[2018-07-10 10:41:48.514] Discovering profile
DEBU[2018-07-10 10:41:48.823] Subscribing to NMP response characteristic
DEBU[2018-07-10 10:41:48.943] {add-nmp-listener} [bll_sesn.go:415] seq=66
DEBU[2018-07-10 10:41:48.943] Serialized OMP TCP request:
Hdr {Op:0 Flags:0 Len:0 Group:4 Seq:66 Id:0}:
00000000  00 00 00 00 00 04 42 00                           |......B.|

Payload:00000000  a4 62 5f 68 48 00 00 00  00 00 04 42 00 68 6c 6f  |.b_hH......B.hlo|
00000010  67 5f 6e 61 6d 65 60 62  74 73 00 65 69 6e 64 65  |g_name`bts.einde|
00000020  78 00                                             |x.|

Data:
00000000  d0 1b 03 b4 6f 6d 67 72  ff a4 62 5f 68 48 00 00  |....omgr..b_hH..|
00000010  00 00 00 04 42 00 68 6c  6f 67 5f 6e 61 6d 65 60  |....B.hlog_name`|
00000020  62 74 73 00 65 69 6e 64  65 78 00                 |bts.eindex.|

DEBU[2018-07-10 10:41:48.943] Tx OMP request: 00000000  d0 1b 03 b4 6f 6d 67 72  ff a4 62 5f 68 48 00 00  |....omgr..b_hH..|
00000010  00 00 00 04 42 00 68 6c  6f 67 5f 6e 61 6d 65 60  |....B.hlog_name`|
00000020  62 74 73 00 65 69 6e 64  65 78 00                 |bts.eindex.|

DEBU[2018-07-10 10:41:49.049] OMP decode failure: Error decoding OMP response: Invalid response: Invalid LogEntryType string:
```

The code was attempting to marshal and unmarshal the log-entry-type as a CBOR string.  That is, rather than converting to and from a raw string, it was using CBOR encoding (type+length prefix).  This is not correct; the raw values of the log response struct are ultimately encoded or decoded using the CBOR codec library, so encoding an individual field as CBOR causes a double encoding.

Also, the function type of `(l LogEntryType) MarshalBinary()` was incorrect.  It should take no arguments and return `([]byte, error)`.