### PR TITLE
res - remove type from res commands

### DIFF
--- a/newtmgr/cli/interactive.go
+++ b/newtmgr/cli/interactive.go
@@ -28,7 +28,6 @@ import (
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
-	"mynewt.apache.org/newtmgr/nmxact/sesn"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
 	"strconv"
 	"strings"

--- a/newtmgr/cli/interactive.go
+++ b/newtmgr/cli/interactive.go
@@ -44,7 +44,6 @@ type ObserveElem struct {
 	Path       string
 }
 
-var ResourceType string
 var ResourcePath string
 var ObserversList *list.List
 
@@ -85,34 +84,23 @@ func copyFromMap(m map[string]interface{}, key string) (value string) {
 
 func hasStoredParams() bool {
 
-	if strings.Compare(ResourcePath, "") == 0 || strings.Compare(ResourceType, "") == 0 {
+	if strings.Compare(ResourcePath, "") == 0 {
 		return false
 	}
 
 	return true
 }
 
-func getPathAndType(m map[string]interface{}) {
+func getPath(m map[string]interface{}) {
 
 	rpath := copyFromMap(m, "path")
-	rtype := copyFromMap(m, "type")
 
 	if strings.Compare(rpath, "") != 0 {
 		ResourcePath = rpath
 	}
-
-	if strings.Compare(rtype, "") != 0 {
-		ResourceType = rtype
-	}
 }
 
 func getCmdCommon(c *ishell.Context, observe int, token []byte) error {
-
-	rt, err := sesn.ParseResType(ResourceType)
-	if err != nil {
-		c.Println("Incorrect resource type")
-		return err
-	}
 
 	s, err := GetSesn()
 	if err != nil {
@@ -123,7 +111,6 @@ func getCmdCommon(c *ishell.Context, observe int, token []byte) error {
 	cmd.SetTxOptions(nmutil.TxOptions())
 	cmd.Path = ResourcePath
 	cmd.Observe = observe
-	cmd.Typ = rt
 	cmd.NotifyFunc = notificationCb
 	cmd.StopSignal = make(chan int)
 	cmd.Token = token
@@ -161,11 +148,11 @@ func getCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
 		return
 	}
@@ -174,7 +161,6 @@ func getCmd(c *ishell.Context) {
 
 	c.Println("command: ", c.Cmd.Name)
 	c.Println("path: ", ResourcePath)
-	c.Println("type: ", ResourceType)
 	c.Println()
 
 	getCmdCommon(c, -1, nil)
@@ -185,11 +171,11 @@ func registerCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
 		return
 	}
@@ -198,7 +184,6 @@ func registerCmd(c *ishell.Context) {
 
 	c.Println("Register for notifications")
 	c.Println("path: ", ResourcePath)
-	c.Println("type: ", ResourceType)
 	c.Println()
 
 	getCmdCommon(c, 0, nil)
@@ -209,11 +194,11 @@ func unregisterCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
 		return
 	}
@@ -286,18 +271,12 @@ func putCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
-		return
-	}
-
-	rt, err := sesn.ParseResType(ResourceType)
-	if err != nil {
-		c.Println("Incorrect resource type")
 		return
 	}
 
@@ -320,7 +299,6 @@ func putCmd(c *ishell.Context) {
 	cmd := xact.NewPutResCmd()
 	cmd.SetTxOptions(nmutil.TxOptions())
 	cmd.Path = ResourcePath
-	cmd.Typ = rt
 	cmd.Value = b
 
 	res, err := cmd.Run(s)
@@ -347,18 +325,12 @@ func postCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
-		return
-	}
-
-	rt, err := sesn.ParseResType(ResourceType)
-	if err != nil {
-		c.Println("Incorrect resource type")
 		return
 	}
 
@@ -381,7 +353,6 @@ func postCmd(c *ishell.Context) {
 	cmd := xact.NewPostResCmd()
 	cmd.SetTxOptions(nmutil.TxOptions())
 	cmd.Path = ResourcePath
-	cmd.Typ = rt
 	cmd.Value = b
 
 	res, err := cmd.Run(s)
@@ -408,11 +379,11 @@ func deleteCmd(c *ishell.Context) {
 	if err != nil || len(c.Args) == 0 {
 		c.Println("Incorrect or no parameters provided ... using cached ones")
 	} else {
-		getPathAndType(m)
+		getPath(m)
 	}
 
 	if hasStoredParams() == false {
-		c.Println("Missing resource path or type")
+		c.Println("Missing resource path")
 		c.Println(c.HelpText())
 		return
 	}
@@ -422,16 +393,9 @@ func deleteCmd(c *ishell.Context) {
 		nmUsage(nil, err)
 	}
 
-	rt, err := sesn.ParseResType(ResourceType)
-	if err != nil {
-		c.Println("Incorrect resource type")
-		return
-	}
-
 	cmd := xact.NewDeleteResCmd()
 	cmd.SetTxOptions(nmutil.TxOptions())
 	cmd.Path = ResourcePath
-	cmd.Typ = rt
 
 	res, err := cmd.Run(s)
 	if err != nil {
@@ -480,31 +444,31 @@ func startInteractive(cmd *cobra.Command, args []string) {
 
 	shell.AddCmd(&ishell.Cmd{
 		Name: "get",
-		Help: "Send a CoAP GET request: get path=v type=v",
+		Help: "Send a CoAP GET request: get path=v",
 		Func: getCmd,
 	})
 
 	shell.AddCmd(&ishell.Cmd{
 		Name: "put",
-		Help: "Send a CoAP PUT request: path=v type=v <you will be asked for params>",
+		Help: "Send a CoAP PUT request: path=v <you will be asked for params>",
 		Func: putCmd,
 	})
 
 	shell.AddCmd(&ishell.Cmd{
 		Name: "post",
-		Help: "Send a CoAP POST request: post type=v path=v <you will be asked for params>",
+		Help: "Send a CoAP POST request: post path=v <you will be asked for params>",
 		Func: postCmd,
 	})
 
 	shell.AddCmd(&ishell.Cmd{
 		Name: "delete",
-		Help: "Send a CoAP POST request: delete type=v path=v",
+		Help: "Send a CoAP POST request: delete path=v",
 		Func: deleteCmd,
 	})
 
 	shell.AddCmd(&ishell.Cmd{
 		Name: "reg",
-		Help: "Register for notifications: req path=v type=v",
+		Help: "Register for notifications: req path=v",
 		Func: registerCmd,
 	})
 

--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -32,7 +32,6 @@ import (
 	"mynewt.apache.org/newt/util"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
-	"mynewt.apache.org/newtmgr/nmxact/sesn"
 	"mynewt.apache.org/newtmgr/nmxact/xact"
 )
 
@@ -185,7 +184,7 @@ func resResponseStr(path string, cbor []byte) string {
 }
 
 func resGetCmd(cmd *cobra.Command, args []string) {
-	if len(args) < 2 {
+	if len(args) < 1 {
 		nmUsage(cmd, nil)
 	}
 
@@ -194,17 +193,11 @@ func resGetCmd(cmd *cobra.Command, args []string) {
 		nmUsage(nil, err)
 	}
 
-	rt, err := sesn.ParseResType(args[0])
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	path := args[1]
+	path := args[0]
 
 	c := xact.NewGetResCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Path = path
-	c.Typ = rt
 
 	res, err := c.Run(s)
 	if err != nil {
@@ -228,7 +221,7 @@ func resGetCmd(cmd *cobra.Command, args []string) {
 }
 
 func resPutCmd(cmd *cobra.Command, args []string) {
-	if len(args) < 3 {
+	if len(args) < 2 {
 		nmUsage(cmd, nil)
 	}
 
@@ -237,15 +230,10 @@ func resPutCmd(cmd *cobra.Command, args []string) {
 		nmUsage(nil, err)
 	}
 
-	rt, err := sesn.ParseResType(args[0])
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	path := args[1]
+	path := args[0]
 
 	var m map[string]interface{}
-	m, err = extractResKv(args[2:])
+	m, err = extractResKv(args[1:])
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -258,7 +246,6 @@ func resPutCmd(cmd *cobra.Command, args []string) {
 	c := xact.NewPutResCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Path = path
-	c.Typ = rt
 	c.Value = b
 
 	res, err := c.Run(s)
@@ -283,7 +270,7 @@ func resPutCmd(cmd *cobra.Command, args []string) {
 }
 
 func resPostCmd(cmd *cobra.Command, args []string) {
-	if len(args) < 3 {
+	if len(args) < 2 {
 		nmUsage(cmd, nil)
 	}
 
@@ -292,12 +279,7 @@ func resPostCmd(cmd *cobra.Command, args []string) {
 		nmUsage(nil, err)
 	}
 
-	rt, err := sesn.ParseResType(args[0])
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	path := args[1]
+	path := args[0]
 
 	var m map[string]interface{}
 	m, err = extractResKv(args[2:])
@@ -313,7 +295,6 @@ func resPostCmd(cmd *cobra.Command, args []string) {
 	c := xact.NewPostResCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Path = path
-	c.Typ = rt
 	c.Value = b
 
 	res, err := c.Run(s)
@@ -338,7 +319,7 @@ func resPostCmd(cmd *cobra.Command, args []string) {
 }
 
 func resDeleteCmd(cmd *cobra.Command, args []string) {
-	if len(args) < 2 {
+	if len(args) < 1 {
 		nmUsage(cmd, nil)
 	}
 
@@ -347,12 +328,7 @@ func resDeleteCmd(cmd *cobra.Command, args []string) {
 		nmUsage(nil, err)
 	}
 
-	rt, err := sesn.ParseResType(args[0])
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	path := args[1]
+	path := args[0]
 
 	var m map[string]interface{}
 	m, err = extractResKv(args[2:])
@@ -368,7 +344,6 @@ func resDeleteCmd(cmd *cobra.Command, args []string) {
 	c := xact.NewDeleteResCmd()
 	c.SetTxOptions(nmutil.TxOptions())
 	c.Path = path
-	c.Typ = rt
 	c.Value = b
 
 	res, err := c.Run(s)
@@ -402,25 +377,25 @@ func resCmd() *cobra.Command {
 	}
 
 	resCmd.AddCommand(&cobra.Command{
-		Use:   "get <type> <path>",
+		Use:   "get <path>",
 		Short: "Send a CoAP GET request",
 		Run:   resGetCmd,
 	})
 
 	resCmd.AddCommand(&cobra.Command{
-		Use:   "put <type> <path> <k=v> [k=v] [k=v]",
+		Use:   "put <path> <k=v> [k=v] [k=v]",
 		Short: "Send a CoAP PUT request",
 		Run:   resPutCmd,
 	})
 
 	resCmd.AddCommand(&cobra.Command{
-		Use:   "post <type> <path> <k=v> [k=v] [k=v]",
+		Use:   "post <path> <k=v> [k=v] [k=v]",
 		Short: "Send a CoAP POST request",
 		Run:   resPostCmd,
 	})
 
 	resCmd.AddCommand(&cobra.Command{
-		Use:   "delete <type> <path>",
+		Use:   "delete <path>",
 		Short: "Send a CoAP DELETE request",
 		Run:   resDeleteCmd,
 	})

--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -282,7 +282,7 @@ func resPostCmd(cmd *cobra.Command, args []string) {
 	path := args[0]
 
 	var m map[string]interface{}
-	m, err = extractResKv(args[2:])
+	m, err = extractResKv(args[1:])
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -331,7 +331,7 @@ func resDeleteCmd(cmd *cobra.Command, args []string) {
 	path := args[0]
 
 	var m map[string]interface{}
-	m, err = extractResKv(args[2:])
+	m, err = extractResKv(args[1:])
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/nmxact/sesn/sesn_cfg.go
+++ b/nmxact/sesn/sesn_cfg.go
@@ -64,16 +64,6 @@ func (r ResourceType) String() string {
 	return resTypeMap[r]
 }
 
-func ParseResType(s string) (ResourceType, error) {
-	for r, n := range resTypeMap {
-		if s == n {
-			return r, nil
-		}
-	}
-
-	return ResourceType(0), fmt.Errorf("Unknown resource type: %s", s)
-}
-
 type OnCloseFn func(s Sesn, err error)
 
 type PeerSpec struct {

--- a/nmxact/sesn/sesn_cfg.go
+++ b/nmxact/sesn/sesn_cfg.go
@@ -20,7 +20,6 @@
 package sesn
 
 import (
-	"fmt"
 	"time"
 
 	"mynewt.apache.org/newtmgr/nmxact/bledefs"


### PR DESCRIPTION
Removes type field from res and interactive commands as it is not used anymore.
As a result, this also removes ParseResType.