### PR TITLE
res - add details flag for res commands

### DIFF
--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -36,6 +36,8 @@ import (
 	"mynewt.apache.org/newtmgr/nmxact/xact"
 )
 
+var details bool
+
 func indent(s string, numSpaces int) string {
 	b := make([]byte, numSpaces)
 	for i, _ := range b {


### PR DESCRIPTION
This commit adds an optional flag for res commands and shows
additional details about the CoAP response. Currently, only the CoAP
code is shown with the flag, while the GET command also shows the Token
if it exists. This is based on the struct of *Cmd*ResResult.