### PR TITLE
Fix build on windows

### DIFF
--- a/newtmgr/bll/bll_xports_windows.go
+++ b/newtmgr/bll/bll_xports_windows.go
@@ -41,11 +41,13 @@ func NewXportCfg() XportCfg {
 
 type BllXport struct {
 	cfg XportCfg
+	hciIdx int
 }
 
-func NewBllXport(cfg XportCfg) *BllXport {
+func NewBllXport(cfg XportCfg, hciIdx int) *BllXport {
 	return &BllXport{
 		cfg: cfg,
+		hciIdx: hciIdx,
 	}
 }
 

--- a/newtmgr/config/bll_config_windows.go
+++ b/newtmgr/config/bll_config_windows.go
@@ -34,6 +34,7 @@ type BllConfig struct {
 	OwnAddrType bledefs.BleAddrType
 	PeerId      string
 	PeerName    string
+	HciIdx	    int
 }
 
 func NewBllConfig() *BllConfig {


### PR DESCRIPTION
$ go install
  mynewt.apache.org/newtmgr/newtmgr/cli
cli\common.go:134:32: too many arguments in call to bll.NewBllXport
cli\common.go:134:40: bc.HciIdx undefined (type *config.BllConfig has no field or method HciIdx)