### PR TITLE
Allow alternate omgr resource

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -83,6 +83,9 @@ func Commands() *cobra.Command {
 	nmCmd.PersistentFlags().StringVar(&nmutil.ConnExtra, "connextra", "",
 		"Additional key-value pair to append to the connstring")
 
+	nmCmd.PersistentFlags().StringVar(&nmxutil.OmpRes, "ompres", "/omgr",
+		"Use this CoAP resource instead of /omgr")
+
 	versCmd := &cobra.Command{
 		Use:     "version",
 		Short:   "Display the " + nmutil.ToolInfo.ShortName + " version number",

--- a/nmxact/nmxutil/nmxutil.go
+++ b/nmxact/nmxutil/nmxutil.go
@@ -39,6 +39,7 @@ import (
 const DURATION_FOREVER time.Duration = math.MaxInt64
 
 var Debug bool
+var OmpRes string = "/omgr"
 
 var nextNmpSeq uint8
 var nmpSeqBeenRead bool

--- a/nmxact/omp/dispatch.go
+++ b/nmxact/omp/dispatch.go
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 
 	log "github.com/Sirupsen/logrus"
-        "github.com/runtimeco/go-coap"
+	"github.com/runtimeco/go-coap"
 
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -30,6 +30,7 @@ import (
 
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
+	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 )
 
 // OIC wrapping adds this many bytes to an NMP message.  Calculated by
@@ -46,7 +47,6 @@ type OicMsg struct {
  * newtmgr response part.
  */
 func DecodeOmp(m coap.Message, rxFilterCb nmcoap.MsgFilter) (nmp.NmpRsp, error) {
-
 	// Ignore non-responses.
 	if m.Code() == coap.GET || m.Code() == coap.PUT || m.Code() == coap.POST ||
 		m.Code() == coap.DELETE {
@@ -115,7 +115,7 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 		er.m = coap.NewDgramMessage(mp)
 	}
 
-	er.m.SetPathString("/omgr")
+	er.m.SetPathString(nmxutil.OmpRes)
 
 	payload := []byte{}
 	enc := codec.NewEncoderBytes(&payload, new(codec.CborHandle))


### PR DESCRIPTION
This commit adds the `--ompres` (OMP resource) command line switch.  If specified, newtmgr sends its OMP request to the specified resource instead of `/omgr`.