### PR TITLE
Allow upgrade-only requests

### DIFF
--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -43,6 +43,7 @@ var (
 )
 
 var noerase bool
+var upgrade bool
 
 func imageFlagsStr(image nmp.ImageStateEntry) string {
 	strs := []string{}
@@ -189,6 +190,7 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 	if noerase == true {
 		c.NoErase = true
 	}
+	c.Upgrade = upgrade
 	c.ProgressBar = pb.StartNew(len(imageFile))
 	c.ProgressBar.SetUnits(pb.U_BYTES)
 	c.ProgressBar.ShowSpeed = true
@@ -397,6 +399,10 @@ func imageCmd() *cobra.Command {
 	uploadCmd.PersistentFlags().BoolVarP(&noerase,
 		"noerase", "e", false,
 		"Don't send specific image erase command to start with")
+	uploadCmd.PersistentFlags().BoolVarP(&upgrade,
+		"upgrade", "u", false,
+		"Only allow the upload if the new image's version is greater than "+
+			"that of the currently running image")
 	imageCmd.AddCommand(uploadCmd)
 
 	coreListCmd := &cobra.Command{

--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -19,18 +19,17 @@
 
 package nmp
 
-import ()
-
 //////////////////////////////////////////////////////////////////////////////
 // $upload                                                                  //
 //////////////////////////////////////////////////////////////////////////////
 
 type ImageUploadReq struct {
-	NmpBase         `codec:"-"`
-	Off      uint32 `codec:"off"`
-	Len      uint32 `codec:"len,omitempty"`
-	DataSha  []byte `codec:"sha,omitempty"`
-	Data     []byte `codec:"data"`
+	NmpBase `codec:"-"`
+	Off     uint32 `codec:"off"`
+	Len     uint32 `codec:"len,omitempty"`
+	DataSha []byte `codec:"sha,omitempty"`
+	Upgrade bool   `codec:"upgrade,omitempty"`
+	Data    []byte `codec:"data"`
 }
 
 type ImageUploadRsp struct {
@@ -97,7 +96,7 @@ type ImageStateReadReq struct {
 }
 
 type ImageStateWriteReq struct {
-	NmpBase        `codec:"-"`
+	NmpBase `codec:"-"`
 	Hash    []byte `codec:"hash"`
 	Confirm bool   `codec:"confirm"`
 }
@@ -163,8 +162,8 @@ func (r *CoreListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 //////////////////////////////////////////////////////////////////////////////
 
 type CoreLoadReq struct {
-	NmpBase    `codec:"-"`
-	Off uint32 `codec:"off"`
+	NmpBase `codec:"-"`
+	Off     uint32 `codec:"off"`
 }
 
 type CoreLoadRsp struct {


### PR DESCRIPTION
This commit adds an additional boolean field to the "image upload" request: `upgrade`.  If this field is true, the firmware will only accept an upload attempt if the new image's version number is greater
than that of the currently running image (using a semver-compatible comparision).

If the `upgrade` field is false or missing, no version check is performed.

The firmware only processes the `upgrade` field on the first image chunk.  It is harmless, but pointless, for a client to specify `upgrade` in any subsequent chunks.