### PR TITLE
Add new command: `shell exec`

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -116,6 +116,7 @@ func Commands() *cobra.Command {
 	nmCmd.AddCommand(echoCmd())
 	nmCmd.AddCommand(resCmd())
 	nmCmd.AddCommand(interactiveCmd())
+	nmCmd.AddCommand(shellCmd())
 
 	return nmCmd
 }

--- a/newtmgr/cli/shell.go
+++ b/newtmgr/cli/shell.go
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"mynewt.apache.org/newt/util"
+	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
+	"mynewt.apache.org/newtmgr/nmxact/xact"
+)
+
+func shellExecCmd(cmd *cobra.Command, args []string) {
+	s, err := GetSesn()
+	if err != nil {
+		nmUsage(nil, err)
+	}
+
+	c := xact.NewShellExecCmd()
+	c.SetTxOptions(nmutil.TxOptions())
+
+	if len(args) == 0 {
+		nmUsage(cmd, nil)
+	}
+
+	c.Argv = args
+
+	res, err := c.Run(s)
+	if err != nil {
+		nmUsage(nil, util.ChildNewtError(err))
+	}
+
+	sres := res.(*xact.ShellExecResult)
+	fmt.Printf("status=%d\n", sres.Rsp.Rc)
+	if len(sres.Rsp.O) > 0 {
+		fmt.Printf("%s", sres.Rsp.O)
+		if sres.Rsp.O[len(sres.Rsp.O)-1] != '\n' {
+			fmt.Printf("\n")
+		}
+	}
+}
+
+func shellCmd() *cobra.Command {
+	shellCmd := &cobra.Command{
+		Use:   "shell",
+		Short: "Execute shell commands remotely",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.HelpFunc()(cmd, args)
+		},
+	}
+
+	execCmd := &cobra.Command{
+		Use:   "exec <command> [args...]",
+		Short: "Execute a shell command remotely",
+		Run:   shellExecCmd,
+	}
+
+	shellCmd.AddCommand(execCmd)
+
+	return shellCmd
+}

--- a/nmxact/nmp/decode.go
+++ b/nmxact/nmp/decode.go
@@ -36,6 +36,7 @@ const gr_log = NMP_GROUP_LOG
 const gr_cra = NMP_GROUP_CRASH
 const gr_run = NMP_GROUP_RUN
 const gr_fil = NMP_GROUP_FS
+const gr_she = NMP_GROUP_SHELL
 
 // Op-Group-Id
 type Ogi struct {
@@ -72,6 +73,7 @@ func fsDownloadRspCtor() NmpRsp    { return NewFsDownloadRsp() }
 func fsUploadRspCtor() NmpRsp      { return NewFsUploadRsp() }
 func configReadRspCtor() NmpRsp    { return NewConfigReadRsp() }
 func configWriteRspCtor() NmpRsp   { return NewConfigWriteRsp() }
+func shellExecRspCtor() NmpRsp     { return NewShellExecRsp() }
 
 var rspCtorMap = map[Ogi]rspCtor{
 	{op_wr, gr_def, NMP_ID_DEF_ECHO}:         echoRspCtor,
@@ -101,6 +103,7 @@ var rspCtorMap = map[Ogi]rspCtor{
 	{op_wr, gr_fil, NMP_ID_FS_FILE}:          fsUploadRspCtor,
 	{op_rr, gr_cfg, NMP_ID_CONFIG_VAL}:       configReadRspCtor,
 	{op_wr, gr_cfg, NMP_ID_CONFIG_VAL}:       configWriteRspCtor,
+	{op_wr, gr_she, NMP_ID_SHELL_EXEC}:       shellExecRspCtor,
 }
 
 func DecodeRspBody(hdr *NmpHdr, body []byte) (NmpRsp, error) {

--- a/nmxact/nmp/defs.go
+++ b/nmxact/nmp/defs.go
@@ -48,6 +48,7 @@ const (
 	NMP_GROUP_SPLIT   = 6
 	NMP_GROUP_RUN     = 7
 	NMP_GROUP_FS      = 8
+	NMP_GROUP_SHELL   = 9
 	NMP_GROUP_PERUSER = 64
 )
 
@@ -105,4 +106,9 @@ const (
 // File system group (8).
 const (
 	NMP_ID_FS_FILE = 0
+)
+
+// Shell group (8).
+const (
+	NMP_ID_SHELL_EXEC = 0
 )

--- a/nmxact/nmp/run.go
+++ b/nmxact/nmp/run.go
@@ -19,14 +19,12 @@
 
 package nmp
 
-import ()
-
 //////////////////////////////////////////////////////////////////////////////
 // $test                                                                    //
 //////////////////////////////////////////////////////////////////////////////
 
 type RunTestReq struct {
-	NmpBase         `codec:"-"`
+	NmpBase  `codec:"-"`
 	Testname string `codec:"testname"`
 	Token    string `codec:"token"`
 }

--- a/nmxact/nmp/shell.go
+++ b/nmxact/nmp/shell.go
@@ -1,0 +1,44 @@
+package nmp
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+type ShellExecReq struct {
+	NmpBase `codec:"-"`
+	Argv    []string `codec:"argv"`
+}
+
+type ShellExecRsp struct {
+	NmpBase `codec:"-"`
+	O       string `codec:"o"`
+	Rc      int    `codec:"rc"`
+}
+
+func NewShellExecReq() *ShellExecReq {
+	r := &ShellExecReq{}
+	fillNmpReq(r, NMP_OP_WRITE, NMP_GROUP_SHELL, NMP_ID_SHELL_EXEC)
+	return r
+}
+
+func NewShellExecRsp() *ShellExecRsp {
+	return &ShellExecRsp{}
+}
+
+func (r *ShellExecReq) Msg() *NmpMsg { return MsgFromReq(r) }
+func (r *ShellExecRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/xact/shell.go
+++ b/nmxact/xact/shell.go
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package xact
+
+import (
+	"mynewt.apache.org/newtmgr/nmxact/nmp"
+	"mynewt.apache.org/newtmgr/nmxact/sesn"
+)
+
+type ShellExecCmd struct {
+	CmdBase
+	Argv []string
+}
+
+func NewShellExecCmd() *ShellExecCmd {
+	return &ShellExecCmd{
+		CmdBase: NewCmdBase(),
+	}
+}
+
+type ShellExecResult struct {
+	Rsp *nmp.ShellExecRsp
+}
+
+func newShellExecResult() *ShellExecResult {
+	return &ShellExecResult{}
+}
+
+func (r *ShellExecResult) Status() int {
+	return r.Rsp.Rc
+}
+
+func (c *ShellExecCmd) Run(s sesn.Sesn) (Result, error) {
+	r := nmp.NewShellExecReq()
+	r.Argv = c.Argv
+
+	rsp, err := txReq(s, r.Msg(), &c.CmdBase)
+	if err != nil {
+		return nil, err
+	}
+	srsp := rsp.(*nmp.ShellExecRsp)
+
+	res := newShellExecResult()
+	res.Rsp = srsp
+	return res, nil
+}


### PR DESCRIPTION
This command executes the specified CLI command on the target device. The response contains the CLI output that would have been sent to the console.

Example usage:
```
newtmgr --conntype oic_ble --connstring peer_name=mydev shell exec stat ble_gattc
```

A different PR adds the `shell exec` command handler to mynewt-core: https://github.com/apache/mynewt-core/pull/1809