### PR TITLE
Move `Msg()` method into `NmpBase` parent

### DIFF
--- a/nmxact/nmp/config.go
+++ b/nmxact/nmp/config.go
@@ -19,14 +19,12 @@
 
 package nmp
 
-import ()
-
 //////////////////////////////////////////////////////////////////////////////
 // $read                                                                    //
 //////////////////////////////////////////////////////////////////////////////
 
 type ConfigReadReq struct {
-	NmpBase        `codec:"-"`
+	NmpBase `codec:"-"`
 	Name    string `codec:"name"`
 }
 
@@ -42,23 +40,19 @@ func NewConfigReadReq() *ConfigReadReq {
 	return r
 }
 
-func (r *ConfigReadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewConfigReadRsp() *ConfigReadRsp {
 	return &ConfigReadRsp{}
 }
-
-func (r *ConfigReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $write                                                                   //
 //////////////////////////////////////////////////////////////////////////////
 
 type ConfigWriteReq struct {
-	NmpBase     `codec:"-"`
-	Name string `codec:"name,omitempty"`
-	Val  string `codec:"val,omitempty"`
-	Save bool   `codec:"save,omitempty"`
+	NmpBase `codec:"-"`
+	Name    string `codec:"name,omitempty"`
+	Val     string `codec:"val,omitempty"`
+	Save    bool   `codec:"save,omitempty"`
 }
 
 type ConfigWriteRsp struct {
@@ -72,10 +66,6 @@ func NewConfigWriteReq() *ConfigWriteReq {
 	return r
 }
 
-func (r *ConfigWriteReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewConfigWriteRsp() *ConfigWriteRsp {
 	return &ConfigWriteRsp{}
 }
-
-func (r *ConfigWriteRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/crash.go
+++ b/nmxact/nmp/crash.go
@@ -19,10 +19,8 @@
 
 package nmp
 
-import ()
-
 type CrashReq struct {
-	NmpBase          `codec:"-"`
+	NmpBase   `codec:"-"`
 	CrashType string `codec:"t"`
 }
 
@@ -37,10 +35,6 @@ func NewCrashReq() *CrashReq {
 	return r
 }
 
-func (r *CrashReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewCrashRsp() *CrashRsp {
 	return &CrashRsp{}
 }
-
-func (r *CrashRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/datetime.go
+++ b/nmxact/nmp/datetime.go
@@ -19,8 +19,6 @@
 
 package nmp
 
-import ()
-
 ///////////////////////////////////////////////////////////////////////////////
 // $read                                                                     //
 ///////////////////////////////////////////////////////////////////////////////
@@ -41,20 +39,16 @@ func NewDateTimeReadReq() *DateTimeReadReq {
 	return r
 }
 
-func (r *DateTimeReadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewDateTimeReadRsp() *DateTimeReadRsp {
 	return &DateTimeReadRsp{}
 }
-
-func (r *DateTimeReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 ///////////////////////////////////////////////////////////////////////////////
 // $write                                                                    //
 ///////////////////////////////////////////////////////////////////////////////
 
 type DateTimeWriteReq struct {
-	NmpBase         `codec:"-"`
+	NmpBase  `codec:"-"`
 	DateTime string `codec:"datetime"`
 }
 
@@ -69,10 +63,6 @@ func NewDateTimeWriteReq() *DateTimeWriteReq {
 	return r
 }
 
-func (r *DateTimeWriteReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewDateTimeWriteRsp() *DateTimeWriteRsp {
 	return &DateTimeWriteRsp{}
 }
-
-func (r *DateTimeWriteRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/echo.go
+++ b/nmxact/nmp/echo.go
@@ -19,10 +19,8 @@
 
 package nmp
 
-import ()
-
 type EchoReq struct {
-	NmpBase        `codec:"-"`
+	NmpBase `codec:"-"`
 	Payload string `codec:"d"`
 }
 
@@ -38,10 +36,6 @@ func NewEchoReq() *EchoReq {
 	return r
 }
 
-func (r *EchoReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewEchoRsp() *EchoRsp {
 	return &EchoRsp{}
 }
-
-func (r *EchoRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/fs.go
+++ b/nmxact/nmp/fs.go
@@ -19,16 +19,14 @@
 
 package nmp
 
-import ()
-
 //////////////////////////////////////////////////////////////////////////////
 // $download                                                                //
 //////////////////////////////////////////////////////////////////////////////
 
 type FsDownloadReq struct {
-	NmpBase     `codec:"-"`
-	Name string `codec:"name"`
-	Off  uint32 `codec:"off"`
+	NmpBase `codec:"-"`
+	Name    string `codec:"name"`
+	Off     uint32 `codec:"off"`
 }
 
 type FsDownloadRsp struct {
@@ -45,24 +43,20 @@ func NewFsDownloadReq() *FsDownloadReq {
 	return r
 }
 
-func (r *FsDownloadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewFsDownloadRsp() *FsDownloadRsp {
 	return &FsDownloadRsp{}
 }
-
-func (r *FsDownloadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $upload                                                                  //
 //////////////////////////////////////////////////////////////////////////////
 
 type FsUploadReq struct {
-	NmpBase     `codec:"-"`
-	Name string `codec:"name"`
-	Len  uint32 `codec:"len"`
-	Off  uint32 `codec:"off"`
-	Data []byte `codec:"data"`
+	NmpBase `codec:"-"`
+	Name    string `codec:"name"`
+	Len     uint32 `codec:"len"`
+	Off     uint32 `codec:"off"`
+	Data    []byte `codec:"data"`
 }
 
 type FsUploadRsp struct {
@@ -77,10 +71,6 @@ func NewFsUploadReq() *FsUploadReq {
 	return r
 }
 
-func (r *FsUploadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewFsUploadRsp() *FsUploadRsp {
 	return &FsUploadRsp{}
 }
-
-func (r *FsUploadRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -44,13 +44,9 @@ func NewImageUploadReq() *ImageUploadReq {
 	return r
 }
 
-func (r *ImageUploadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewImageUploadRsp() *ImageUploadRsp {
 	return &ImageUploadRsp{}
 }
-
-func (r *ImageUploadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $state                                                                   //
@@ -114,21 +110,15 @@ func NewImageStateReadReq() *ImageStateReadReq {
 	return r
 }
 
-func (r *ImageStateReadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewImageStateWriteReq() *ImageStateWriteReq {
 	r := &ImageStateWriteReq{}
 	fillNmpReq(r, NMP_OP_WRITE, NMP_GROUP_IMAGE, NMP_ID_IMAGE_STATE)
 	return r
 }
 
-func (r *ImageStateWriteReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewImageStateRsp() *ImageStateRsp {
 	return &ImageStateRsp{}
 }
-
-func (r *ImageStateRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $corelist                                                                //
@@ -149,13 +139,9 @@ func NewCoreListReq() *CoreListReq {
 	return r
 }
 
-func (r *CoreListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewCoreListRsp() *CoreListRsp {
 	return &CoreListRsp{}
 }
-
-func (r *CoreListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $coreload                                                                //
@@ -180,13 +166,9 @@ func NewCoreLoadReq() *CoreLoadReq {
 	return r
 }
 
-func (r *CoreLoadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewCoreLoadRsp() *CoreLoadRsp {
 	return &CoreLoadRsp{}
 }
-
-func (r *CoreLoadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $coreerase                                                               //
@@ -207,13 +189,9 @@ func NewCoreEraseReq() *CoreEraseReq {
 	return r
 }
 
-func (r *CoreEraseReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewCoreEraseRsp() *CoreEraseRsp {
 	return &CoreEraseRsp{}
 }
-
-func (r *CoreEraseRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $erase                                                                   //
@@ -234,10 +212,6 @@ func NewImageEraseReq() *ImageEraseReq {
 	return r
 }
 
-func (r *ImageEraseReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewImageEraseRsp() *ImageEraseRsp {
 	return &ImageEraseRsp{}
 }
-
-func (r *ImageEraseRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -157,13 +157,9 @@ func NewLogShowReq() *LogShowReq {
 	return r
 }
 
-func (r *LogShowReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewLogShowRsp() *LogShowRsp {
 	return &LogShowRsp{}
 }
-
-func (r *LogShowRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $list                                                                    //
@@ -185,13 +181,9 @@ func NewLogListReq() *LogListReq {
 	return r
 }
 
-func (r *LogListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewLogListRsp() *LogListRsp {
 	return &LogListRsp{}
 }
-
-func (r *LogListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $module list                                                             //
@@ -213,13 +205,9 @@ func NewLogModuleListReq() *LogModuleListReq {
 	return r
 }
 
-func (r *LogModuleListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewLogModuleListRsp() *LogModuleListRsp {
 	return &LogModuleListRsp{}
 }
-
-func (r *LogModuleListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $level list                                                              //
@@ -241,13 +229,9 @@ func NewLogLevelListReq() *LogLevelListReq {
 	return r
 }
 
-func (r *LogLevelListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewLogLevelListRsp() *LogLevelListRsp {
 	return &LogLevelListRsp{}
 }
-
-func (r *LogLevelListRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $clear                                                                   //
@@ -268,13 +252,9 @@ func NewLogClearReq() *LogClearReq {
 	return r
 }
 
-func (r *LogClearReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewLogClearRsp() *LogClearRsp {
 	return &LogClearRsp{}
 }
-
-func (r *LogClearRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $LogType Marshal/Unmarshal                                               //

--- a/nmxact/nmp/mpstat.go
+++ b/nmxact/nmp/mpstat.go
@@ -19,8 +19,6 @@
 
 package nmp
 
-import ()
-
 type MempoolStatReq struct {
 	NmpBase `codec:"-"`
 }
@@ -37,10 +35,6 @@ func NewMempoolStatReq() *MempoolStatReq {
 	return r
 }
 
-func (r *MempoolStatReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewMempoolStatRsp() *MempoolStatRsp {
 	return &MempoolStatRsp{}
 }
-
-func (r *MempoolStatRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/nmp.go
+++ b/nmxact/nmp/nmp.go
@@ -27,8 +27,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
-	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 	"mynewt.apache.org/newt/util"
+	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 )
 
 const NMP_HDR_SIZE = 8
@@ -74,10 +74,10 @@ func (b *NmpBase) SetHdr(h *NmpHdr) {
 	b.hdr = *h
 }
 
-func MsgFromReq(r NmpReq) *NmpMsg {
+func (b *NmpBase) Msg() *NmpMsg {
 	return &NmpMsg{
-		*r.Hdr(),
-		r,
+		*b.Hdr(),
+		b,
 	}
 }
 

--- a/nmxact/nmp/reset.go
+++ b/nmxact/nmp/reset.go
@@ -19,8 +19,6 @@
 
 package nmp
 
-import ()
-
 type ResetReq struct {
 	NmpBase `codec:"-"`
 }
@@ -35,10 +33,6 @@ func NewResetReq() *ResetReq {
 	return r
 }
 
-func (r *ResetReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewResetRsp() *ResetRsp {
 	return &ResetRsp{}
 }
-
-func (r *ResetRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/run.go
+++ b/nmxact/nmp/run.go
@@ -42,13 +42,9 @@ func NewRunTestReq() *RunTestReq {
 	return r
 }
 
-func (r *RunTestReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewRunTestRsp() *RunTestRsp {
 	return &RunTestRsp{}
 }
-
-func (r *RunTestRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $list                                                                    //
@@ -70,10 +66,6 @@ func NewRunListReq() *RunListReq {
 	return r
 }
 
-func (r *RunListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewRunListRsp() *RunListRsp {
 	return &RunListRsp{}
 }
-
-func (r *RunListRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/stat.go
+++ b/nmxact/nmp/stat.go
@@ -19,15 +19,13 @@
 
 package nmp
 
-import ()
-
 //////////////////////////////////////////////////////////////////////////////
 // $read                                                                    //
 //////////////////////////////////////////////////////////////////////////////
 
 type StatReadReq struct {
-	NmpBase     `codec:"-"`
-	Name string `codec:"name"`
+	NmpBase `codec:"-"`
+	Name    string `codec:"name"`
 }
 
 type StatReadRsp struct {
@@ -44,13 +42,9 @@ func NewStatReadReq() *StatReadReq {
 	return r
 }
 
-func (r *StatReadReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewStatReadRsp() *StatReadRsp {
 	return &StatReadRsp{}
 }
-
-func (r *StatReadRsp) Msg() *NmpMsg { return MsgFromReq(r) }
 
 //////////////////////////////////////////////////////////////////////////////
 // $list                                                                    //
@@ -72,10 +66,6 @@ func NewStatListReq() *StatListReq {
 	return r
 }
 
-func (r *StatListReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewStatListRsp() *StatListRsp {
 	return &StatListRsp{}
 }
-
-func (r *StatListRsp) Msg() *NmpMsg { return MsgFromReq(r) }

--- a/nmxact/nmp/taskstat.go
+++ b/nmxact/nmp/taskstat.go
@@ -19,8 +19,6 @@
 
 package nmp
 
-import ()
-
 type TaskStatReq struct {
 	NmpBase `codec:"-"`
 }
@@ -37,10 +35,6 @@ func NewTaskStatReq() *TaskStatReq {
 	return r
 }
 
-func (r *TaskStatReq) Msg() *NmpMsg { return MsgFromReq(r) }
-
 func NewTaskStatRsp() *TaskStatRsp {
 	return &TaskStatRsp{}
 }
-
-func (r *TaskStatRsp) Msg() *NmpMsg { return MsgFromReq(r) }


### PR DESCRIPTION
Each request and response type implemented this method separately, but all implementations were identical.  This commit moves this method into the base type (`NmpBase`).