### PR TITLE
Update go/codec requirement to v1.1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,8 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/tarm/serial v0.0.0-20170530023055-e50d7d20b1f6
-	github.com/ugorji/go v0.0.0-20170826155943-8c0409fcbb70
+	github.com/ugorji/go v1.1.7
+	github.com/ugorji/go/codec v1.1.7
 	golang.org/x/net v0.0.0-20170828231752-66aacef3dd8a
 	gopkg.in/abiosoft/ishell.v1 v1.0.0-20171224170712-50251d04cb42
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,12 @@ github.com/tarm/serial v0.0.0-20170530023055-e50d7d20b1f6 h1:4D7IbZRb3ZNaCXr262s
 github.com/tarm/serial v0.0.0-20170530023055-e50d7d20b1f6/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/ugorji/go v0.0.0-20170826155943-8c0409fcbb70 h1:zcmkQE363EFyCTXGCo948vuTB9jtOd3xUXomj+Kfr4s=
 github.com/ugorji/go v0.0.0-20170826155943-8c0409fcbb70/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
+github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8 h1:Kcv6ck5PWsaDifMwDDgexKfbmP1k63r3tcVppPa+FyM=
+github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
+github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
+github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20170828231752-66aacef3dd8a h1:DZGc/od29xzgmdBTGZL3zqLaoHS0O+qdIEYJNkOxDKM=
 golang.org/x/net v0.0.0-20170828231752-66aacef3dd8a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Update here and on newt to the same version; should fix build conflicts in tooling that requires both packages, like it happens for `mcumgr-cli`.