### PR TITLE
Remove security requirements from CoAP commands

### DIFF
--- a/nmxact/bledefs/bledefs.go
+++ b/nmxact/bledefs/bledefs.go
@@ -852,14 +852,10 @@ func CompareChrIds(a BleChrId, b BleChrId) int {
 }
 
 type BleMgmtChrs struct {
-	NmpReqChr       *BleChrId
-	NmpRspChr       *BleChrId
-	ResPublicReqChr *BleChrId
-	ResPublicRspChr *BleChrId
-	ResUnauthReqChr *BleChrId
-	ResUnauthRspChr *BleChrId
-	ResSecureReqChr *BleChrId
-	ResSecureRspChr *BleChrId
+	NmpReqChr *BleChrId
+	NmpRspChr *BleChrId
+	ResReqChr *BleChrId
+	ResRspChr *BleChrId
 }
 
 type BleSmAction int

--- a/nmxact/mtech_lora/mtech_lora_sesn.go
+++ b/nmxact/mtech_lora/mtech_lora_sesn.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/joaojeronimo/go-crc16"
 	"github.com/runtimeco/go-coap"
+	log "github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
 	"mynewt.apache.org/newtmgr/nmxact/lora"
@@ -327,7 +327,7 @@ func (s *LoraSesn) AbortRx(seq uint8) error {
 	return nil
 }
 
-func (s *LoraSesn) TxCoapOnce(m coap.Message, resType sesn.ResourceType,
+func (s *LoraSesn) TxCoapOnce(m coap.Message,
 	opt sesn.TxOptions) (coap.COAPCode, []byte, error) {
 
 	if !s.IsOpen() {
@@ -347,8 +347,10 @@ func (s *LoraSesn) TxCoapOnce(m coap.Message, resType sesn.ResourceType,
 	}
 }
 
-func (s *LoraSesn) TxCoapObserve(m coap.Message, resType sesn.ResourceType,
-	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+func (s *LoraSesn) TxCoapObserve(m coap.Message,
+	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb,
+	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+
 	return 0, nil, nil, nil
 }
 

--- a/nmxact/nmble/ble_sesn.go
+++ b/nmxact/nmble/ble_sesn.go
@@ -109,17 +109,16 @@ func (s *BleSesn) TxNmpOnce(req *nmp.NmpMsg, opt sesn.TxOptions) (
 }
 
 func (s *BleSesn) TxCoapOnce(m coap.Message,
-	resType sesn.ResourceType,
 	opt sesn.TxOptions) (coap.COAPCode, []byte, error) {
 
-	return s.Ns.TxCoapOnce(m, resType, opt)
+	return s.Ns.TxCoapOnce(m, opt)
 }
 
 func (s *BleSesn) TxCoapObserve(m coap.Message,
-	resType sesn.ResourceType,
-	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb,
+	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
 
-	return s.Ns.TxCoapObserve(m, resType, opt, NotifCb, stopsignal)
+	return s.Ns.TxCoapObserve(m, opt, NotifCb, stopsignal)
 }
 
 func (s *BleSesn) RxAccept() (sesn.Sesn, *sesn.SesnCfg, error) {

--- a/nmxact/nmble/ble_util.go
+++ b/nmxact/nmble/ble_util.go
@@ -709,30 +709,6 @@ func GattService() BleSvc {
 	}
 }
 
-func ResChrReqIdLookup(mgmtChrs BleMgmtChrs,
-	resType sesn.ResourceType) *BleChrId {
-
-	m := map[sesn.ResourceType]*BleChrId{
-		sesn.RES_TYPE_PUBLIC: mgmtChrs.ResPublicReqChr,
-		sesn.RES_TYPE_UNAUTH: mgmtChrs.ResUnauthReqChr,
-		sesn.RES_TYPE_SECURE: mgmtChrs.ResSecureReqChr,
-	}
-
-	return m[resType]
-}
-
-func ResChrRspIdLookup(mgmtChrs BleMgmtChrs,
-	resType sesn.ResourceType) *BleChrId {
-
-	m := map[sesn.ResourceType]*BleChrId{
-		sesn.RES_TYPE_PUBLIC: mgmtChrs.ResPublicRspChr,
-		sesn.RES_TYPE_UNAUTH: mgmtChrs.ResUnauthRspChr,
-		sesn.RES_TYPE_SECURE: mgmtChrs.ResSecureRspChr,
-	}
-
-	return m[resType]
-}
-
 func BuildMgmtChrs(mgmtProto sesn.MgmtProto) (BleMgmtChrs, error) {
 	mgmtChrs := BleMgmtChrs{}
 
@@ -743,17 +719,9 @@ func BuildMgmtChrs(mgmtProto sesn.MgmtProto) (BleMgmtChrs, error) {
 	ompReqChrUuid, _ := ParseUuid(OmpUnsecReqChrUuid)
 	ompRspChrUuid, _ := ParseUuid(OmpUnsecRspChrUuid)
 
-	publicSvcUuid, _ := ParseUuid(IotivitySvcUuid)
-	publicReqChrUuid, _ := ParseUuid(IotivityReqChrUuid)
-	publicRspChrUuid, _ := ParseUuid(IotivityRspChrUuid)
-
-	unauthSvcUuid, _ := ParseUuid(UnauthSvcUuid)
-	unauthReqChrUuid, _ := ParseUuid(UnauthReqChrUuid)
-	unauthRspChrUuid, _ := ParseUuid(UnauthRspChrUuid)
-
-	secureSvcUuid := NewBleUuid16(SecureSvcUuid)
-	secureReqChrUuid := NewBleUuid16(SecureReqChrUuid)
-	secureRspChrUuid := NewBleUuid16(SecureRspChrUuid)
+	resSvcUuid, _ := ParseUuid(IotivitySvcUuid)
+	resReqChrUuid, _ := ParseUuid(IotivityReqChrUuid)
+	resRspChrUuid, _ := ParseUuid(IotivityRspChrUuid)
 
 	switch mgmtProto {
 	case sesn.MGMT_PROTO_NMP:
@@ -769,12 +737,8 @@ func BuildMgmtChrs(mgmtProto sesn.MgmtProto) (BleMgmtChrs, error) {
 			fmt.Errorf("invalid management protocol: %+v", mgmtProto)
 	}
 
-	mgmtChrs.ResPublicReqChr = &BleChrId{publicSvcUuid, publicReqChrUuid}
-	mgmtChrs.ResPublicRspChr = &BleChrId{publicSvcUuid, publicRspChrUuid}
-	mgmtChrs.ResUnauthReqChr = &BleChrId{unauthSvcUuid, unauthReqChrUuid}
-	mgmtChrs.ResUnauthRspChr = &BleChrId{unauthSvcUuid, unauthRspChrUuid}
-	mgmtChrs.ResSecureReqChr = &BleChrId{secureSvcUuid, secureReqChrUuid}
-	mgmtChrs.ResSecureRspChr = &BleChrId{secureSvcUuid, secureRspChrUuid}
+	mgmtChrs.ResReqChr = &BleChrId{resSvcUuid, resReqChrUuid}
+	mgmtChrs.ResRspChr = &BleChrId{resSvcUuid, resRspChrUuid}
 
 	return mgmtChrs, nil
 }
@@ -795,28 +759,6 @@ func IsSecErr(err error) bool {
 
 	default:
 		return false
-	}
-}
-
-// Indicates the minimum security requirements for accessing the specified
-// resource type.
-//
-// @return bool                 Whether encryption is required.
-// @return bool                 Whether authentiation is required.
-// @return error                Error.
-func ResTypeSecReqs(resType sesn.ResourceType) (bool, bool, error) {
-	switch resType {
-	case sesn.RES_TYPE_PUBLIC:
-		return false, false, nil
-
-	case sesn.RES_TYPE_UNAUTH:
-		return true, false, nil
-
-	case sesn.RES_TYPE_SECURE:
-		return true, true, nil
-
-	default:
-		return false, false, fmt.Errorf("invalid resource type: %+v", resType)
 	}
 }
 

--- a/nmxact/nmserial/serial_sesn.go
+++ b/nmxact/nmserial/serial_sesn.go
@@ -217,7 +217,7 @@ func (s *SerialSesn) TxNmpOnce(m *nmp.NmpMsg, opt sesn.TxOptions) (
 	return s.txvr.TxNmp(txFn, m, s.MtuOut(), opt.Timeout)
 }
 
-func (s *SerialSesn) TxCoapOnce(m coap.Message, resType sesn.ResourceType,
+func (s *SerialSesn) TxCoapOnce(m coap.Message,
 	opt sesn.TxOptions) (coap.COAPCode, []byte, error) {
 
 	if !s.isOpen {
@@ -245,8 +245,10 @@ func (s *SerialSesn) TxCoapOnce(m coap.Message, resType sesn.ResourceType,
 	}
 }
 
-func (s *SerialSesn) TxCoapObserve(m coap.Message, resType sesn.ResourceType,
-	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+func (s *SerialSesn) TxCoapObserve(m coap.Message, opt sesn.TxOptions,
+	NotifCb sesn.GetNotifyCb,
+	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+
 	return 0, nil, nil, nil
 }
 

--- a/nmxact/sesn/sesn.go
+++ b/nmxact/sesn/sesn.go
@@ -105,12 +105,12 @@ type Sesn interface {
 	//     * other error
 	TxNmpOnce(m *nmp.NmpMsg, opt TxOptions) (nmp.NmpRsp, error)
 
-	TxCoapOnce(m coap.Message, resType ResourceType,
-		opt TxOptions) (coap.COAPCode, []byte, error)
+	TxCoapOnce(m coap.Message, opt TxOptions) (coap.COAPCode, []byte, error)
 
-	TxCoapObserve(m coap.Message, resType ResourceType,
-		opt TxOptions, NotifCb GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error)
+	TxCoapObserve(m coap.Message, opt TxOptions, NotifCb GetNotifyCb,
+		stopsignal chan int) (coap.COAPCode, []byte, []byte, error)
 
-	// Returns a transmit and a receive callback used to manipulate CoAP messages
+	// Returns a transmit and a receive callback used to manipulate CoAP
+	// messages
 	Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter)
 }

--- a/nmxact/sesn/sesn_cfg.go
+++ b/nmxact/sesn/sesn_cfg.go
@@ -45,24 +45,6 @@ func (r MgmtProto) String() string {
 	return mgmtProtoMap[r]
 }
 
-type ResourceType int
-
-const (
-	RES_TYPE_PUBLIC ResourceType = iota
-	RES_TYPE_UNAUTH
-	RES_TYPE_SECURE
-)
-
-var resTypeMap = map[ResourceType]string{
-	RES_TYPE_PUBLIC: "public",
-	RES_TYPE_UNAUTH: "unauth",
-	RES_TYPE_SECURE: "secure",
-}
-
-func (r ResourceType) String() string {
-	return resTypeMap[r]
-}
-
 type OnCloseFn func(s Sesn, err error)
 
 type PeerSpec struct {

--- a/nmxact/sesn/sesn_util.go
+++ b/nmxact/sesn/sesn_util.go
@@ -41,19 +41,20 @@ func TxNmp(s Sesn, m *nmp.NmpMsg, o TxOptions) (nmp.NmpRsp, error) {
 	}
 }
 
-func getResourceOnce(s Sesn, resType ResourceType,
-	uri string, opt TxOptions) (coap.COAPCode, []byte, error) {
+func getResourceOnce(s Sesn, uri string,
+	opt TxOptions) (coap.COAPCode, []byte, error) {
 
 	req, err := nmcoap.CreateGet(s.CoapIsTcp(), uri, -1, nmxutil.NextToken())
 	if err != nil {
 		return 0, nil, err
 	}
 
-	return s.TxCoapOnce(req, resType, opt)
+	return s.TxCoapOnce(req, opt)
 }
 
-func getResource(s Sesn, resType ResourceType,
-	uri string, observe int, token []byte, opt TxOptions, NotifCb GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+func getResource(s Sesn, uri string, observe int,
+	token []byte, opt TxOptions, NotifCb GetNotifyCb,
+	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
 
 	var req coap.Message
 	var err error
@@ -68,15 +69,14 @@ func getResource(s Sesn, resType ResourceType,
 	}
 
 	if observe == 0 {
-		return s.TxCoapObserve(req, resType, opt, NotifCb, stopsignal)
+		return s.TxCoapObserve(req, opt, NotifCb, stopsignal)
 	}
 
-	c, r, err := s.TxCoapOnce(req, resType, opt)
+	c, r, err := s.TxCoapOnce(req, opt)
 	return c, r, nil, err
 }
 
-func putResourceOnce(s Sesn, resType ResourceType,
-	uri string, value []byte,
+func putResourceOnce(s Sesn, uri string, value []byte,
 	opt TxOptions) (coap.COAPCode, []byte, error) {
 
 	req, err := nmcoap.CreatePut(s.CoapIsTcp(), uri, nmxutil.NextToken(),
@@ -85,11 +85,10 @@ func putResourceOnce(s Sesn, resType ResourceType,
 		return 0, nil, err
 	}
 
-	return s.TxCoapOnce(req, resType, opt)
+	return s.TxCoapOnce(req, opt)
 }
 
-func postResourceOnce(s Sesn, resType ResourceType,
-	uri string, value []byte,
+func postResourceOnce(s Sesn, uri string, value []byte,
 	opt TxOptions) (coap.COAPCode, []byte, error) {
 
 	req, err := nmcoap.CreatePost(s.CoapIsTcp(), uri, nmxutil.NextToken(),
@@ -98,11 +97,10 @@ func postResourceOnce(s Sesn, resType ResourceType,
 		return 0, nil, err
 	}
 
-	return s.TxCoapOnce(req, resType, opt)
+	return s.TxCoapOnce(req, opt)
 }
 
-func deleteResourceOnce(s Sesn, resType ResourceType,
-	uri string, value []byte,
+func deleteResourceOnce(s Sesn, uri string, value []byte,
 	opt TxOptions) (coap.COAPCode, []byte, error) {
 
 	req, err := nmcoap.CreateDelete(s.CoapIsTcp(), uri, nmxutil.NextToken(),
@@ -111,7 +109,7 @@ func deleteResourceOnce(s Sesn, resType ResourceType,
 		return 0, nil, err
 	}
 
-	return s.TxCoapOnce(req, resType, opt)
+	return s.TxCoapOnce(req, opt)
 }
 
 func txCoap(txCb func() (coap.COAPCode, []byte, error),
@@ -146,49 +144,48 @@ func txCoapObserve(txCb func() (coap.COAPCode, []byte, []byte, error),
 	}
 }
 
-func GetResourceObserve(s Sesn, resType ResourceType, uri string, o TxOptions, notifCb GetNotifyCb,
+func GetResourceObserve(s Sesn, uri string, o TxOptions, notifCb GetNotifyCb,
 	stopsignal chan int, observe int, token []byte) (
 	coap.COAPCode, []byte, []byte, error) {
 
 	return txCoapObserve(func() (coap.COAPCode, []byte, []byte, error) {
-		return getResource(s, resType, uri, observe, token, o, notifCb, stopsignal)
+		return getResource(s, uri, observe, token, o, notifCb, stopsignal)
 	}, o.Tries)
 }
 
-func GetResource(s Sesn, resType ResourceType, uri string, o TxOptions) (
+func GetResource(s Sesn, uri string, o TxOptions) (
 	coap.COAPCode, []byte, error) {
 
 	return txCoap(func() (coap.COAPCode, []byte, error) {
-		return getResourceOnce(s, resType, uri, o)
+		return getResourceOnce(s, uri, o)
 	}, o.Tries)
 }
 
-func PutResource(s Sesn, resType ResourceType, uri string,
+func PutResource(s Sesn, uri string,
 	value []byte, o TxOptions) (coap.COAPCode, []byte, error) {
 
 	return txCoap(func() (coap.COAPCode, []byte, error) {
-		return putResourceOnce(s, resType, uri, value, o)
+		return putResourceOnce(s, uri, value, o)
 	}, o.Tries)
 }
 
-func PostResource(s Sesn, resType ResourceType, uri string,
+func PostResource(s Sesn, uri string,
 	value []byte, o TxOptions) (coap.COAPCode, []byte, error) {
 
 	return txCoap(func() (coap.COAPCode, []byte, error) {
-		return postResourceOnce(s, resType, uri, value, o)
+		return postResourceOnce(s, uri, value, o)
 	}, o.Tries)
 }
 
-func DeleteResource(s Sesn, resType ResourceType, uri string,
-	value []byte, o TxOptions) (coap.COAPCode, []byte, error) {
+func DeleteResource(s Sesn, uri string, value []byte,
+	o TxOptions) (coap.COAPCode, []byte, error) {
 
 	return txCoap(func() (coap.COAPCode, []byte, error) {
-		return deleteResourceOnce(s, resType, uri, value, o)
+		return deleteResourceOnce(s, uri, value, o)
 	}, o.Tries)
 }
 
-func PutCborResource(s Sesn, resType ResourceType, uri string,
-	value map[string]interface{},
+func PutCborResource(s Sesn, uri string, value map[string]interface{},
 	o TxOptions) (coap.COAPCode, map[string]interface{}, error) {
 
 	b, err := nmxutil.EncodeCborMap(value)
@@ -196,7 +193,7 @@ func PutCborResource(s Sesn, resType ResourceType, uri string,
 		return 0, nil, err
 	}
 
-	code, r, err := PutResource(s, resType, uri, b, o)
+	code, r, err := PutResource(s, uri, b, o)
 	m, err := nmxutil.DecodeCborMap(r)
 	if err != nil {
 		return 0, nil, err

--- a/nmxact/udp/udp_sesn.go
+++ b/nmxact/udp/udp_sesn.go
@@ -126,7 +126,7 @@ func (s *UdpSesn) AbortRx(seq uint8) error {
 	return nil
 }
 
-func (s *UdpSesn) TxCoapOnce(m coap.Message, resType sesn.ResourceType,
+func (s *UdpSesn) TxCoapOnce(m coap.Message,
 	opt sesn.TxOptions) (coap.COAPCode, []byte, error) {
 
 	txRaw := func(b []byte) error {
@@ -148,15 +148,17 @@ func (s *UdpSesn) MgmtProto() sesn.MgmtProto {
 	return s.cfg.MgmtProto
 }
 
-func (s *UdpSesn) TxCoapObserve(m coap.Message, resType sesn.ResourceType,
-	opt sesn.TxOptions, NotifyCb sesn.GetNotifyCb, stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+func (s *UdpSesn) TxCoapObserve(m coap.Message, opt sesn.TxOptions,
+	NotifyCb sesn.GetNotifyCb,
+	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
 
 	txRaw := func(b []byte) error {
 		_, err := s.conn.WriteToUDP(b, s.addr)
 		return err
 	}
 
-	rsp, err := s.txvr.TxOicObserve(txRaw, m, s.MtuOut(), opt.Timeout, NotifyCb, stopsignal)
+	rsp, err := s.txvr.TxOicObserve(txRaw, m, s.MtuOut(), opt.Timeout,
+		NotifyCb, stopsignal)
 	if err != nil {
 		return 0, nil, nil, err
 	} else if rsp == nil {

--- a/nmxact/xact/res.go
+++ b/nmxact/xact/res.go
@@ -32,7 +32,6 @@ type GetResCmd struct {
 	NotifyFunc sesn.GetNotifyCb
 	StopSignal chan int
 	Token      []byte
-	Typ        sesn.ResourceType
 }
 
 func NewGetResCmd() *GetResCmd {
@@ -67,10 +66,11 @@ func (c *GetResCmd) Run(s sesn.Sesn) (Result, error) {
 	var err error
 
 	if c.Observe != -1 {
-		status, val, token, err = sesn.GetResourceObserve(s, c.Typ, c.Path, c.TxOptions(),
-			c.NotifyFunc, c.StopSignal, c.Observe, c.Token)
+		status, val, token, err = sesn.GetResourceObserve(
+			s, c.Path, c.TxOptions(), c.NotifyFunc, c.StopSignal, c.Observe,
+			c.Token)
 	} else {
-		status, val, err = sesn.GetResource(s, c.Typ, c.Path, c.TxOptions())
+		status, val, err = sesn.GetResource(s, c.Path, c.TxOptions())
 	}
 
 	if err != nil {
@@ -88,7 +88,6 @@ func (c *GetResCmd) Run(s sesn.Sesn) (Result, error) {
 type PutResCmd struct {
 	CmdBase
 	Path  string
-	Typ   sesn.ResourceType
 	Value []byte
 }
 
@@ -119,7 +118,7 @@ func (r *PutResResult) Status() int {
 }
 
 func (c *PutResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, r, err := sesn.PutResource(s, c.Typ, c.Path, c.Value, c.TxOptions())
+	status, r, err := sesn.PutResource(s, c.Path, c.Value, c.TxOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +132,6 @@ func (c *PutResCmd) Run(s sesn.Sesn) (Result, error) {
 type PostResCmd struct {
 	CmdBase
 	Path  string
-	Typ   sesn.ResourceType
 	Value []byte
 }
 
@@ -164,7 +162,7 @@ func (r *PostResResult) Status() int {
 }
 
 func (c *PostResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, r, err := sesn.PostResource(s, c.Typ, c.Path, c.Value, c.TxOptions())
+	status, r, err := sesn.PostResource(s, c.Path, c.Value, c.TxOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +175,7 @@ func (c *PostResCmd) Run(s sesn.Sesn) (Result, error) {
 
 type DeleteResCmd struct {
 	CmdBase
-	Path string
-	Typ  sesn.ResourceType
+	Path  string
 	Value []byte
 }
 
@@ -206,7 +203,7 @@ func (r *DeleteResResult) Status() int {
 }
 
 func (c *DeleteResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, val, err := sesn.DeleteResource(s, c.Typ, c.Path, c.Value, c.TxOptions())
+	status, val, err := sesn.DeleteResource(s, c.Path, c.Value, c.TxOptions())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR removes a feature that has been unused for years.

Initially, the idea was that each CoAP resource would be defined with one of the following security levels:

* public (no security)
* unauthenticated (encryption)
* secure (encryption and authentication)

A session (connection) would be secured in a transport-specific way, but the main transport under consideration was Bluetooth.  In Bluetooth, characteristics are assigned security levels resembling the three above. To implement this defunct security mechanism in CoAP-over-Bluetooth, we would need three different characteristics, one corresponding to each security level.  When sending a CoAP request, the newtmgr client would choose the correct characteristic based on the secure state of the connection.

This security policy has not been supported in Mynewt for a few years. The code implementing it is unused and unmaintained, so I am removing it now.