### PR TITLE
nmxact: API change for CoAP operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/raff/goble v0.0.0-20170814221208-b12b34f940c4 // indirect
 	github.com/runtimeco/go-coap v0.0.0-20180109101419-47c23e2a63ea
 	github.com/sirupsen/logrus v1.4.1
+	github.com/spf13/cast v1.2.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/tarm/serial v0.0.0-20170530023055-e50d7d20b1f6

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/runtimeco/go-coap v0.0.0-20180109101419-47c23e2a63ea/go.mod h1:x/rLux
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/nmxact/nmble/ble_sesn.go
+++ b/nmxact/nmble/ble_sesn.go
@@ -20,6 +20,8 @@
 package nmble
 
 import (
+	"time"
+
 	"github.com/runtimeco/go-coap"
 
 	. "mynewt.apache.org/newtmgr/nmxact/bledefs"
@@ -102,23 +104,22 @@ func (s *BleSesn) SetOobKey(key []byte) {
 	s.Ns.SetOobKey(key)
 }
 
-func (s *BleSesn) TxNmpOnce(req *nmp.NmpMsg, opt sesn.TxOptions) (
-	nmp.NmpRsp, error) {
+func (s *BleSesn) TxRxMgmt(m *nmp.NmpMsg,
+	timeout time.Duration) (nmp.NmpRsp, error) {
 
-	return s.Ns.TxNmpOnce(req, opt)
+	return s.Ns.TxRxMgmt(m, timeout)
 }
 
-func (s *BleSesn) TxCoapOnce(m coap.Message,
-	opt sesn.TxOptions) (coap.COAPCode, []byte, error) {
-
-	return s.Ns.TxCoapOnce(m, opt)
+func (s *BleSesn) TxCoap(m coap.Message) error {
+	return s.Ns.TxCoap(m)
 }
 
-func (s *BleSesn) TxCoapObserve(m coap.Message,
-	opt sesn.TxOptions, NotifCb sesn.GetNotifyCb,
-	stopsignal chan int) (coap.COAPCode, []byte, []byte, error) {
+func (s *BleSesn) ListenCoap(mc nmcoap.MsgCriteria) (*nmcoap.Listener, error) {
+	return s.Ns.ListenCoap(mc)
+}
 
-	return s.Ns.TxCoapObserve(m, opt, NotifCb, stopsignal)
+func (s *BleSesn) StopListenCoap(mc nmcoap.MsgCriteria) {
+	s.Ns.StopListenCoap(mc)
 }
 
 func (s *BleSesn) RxAccept() (sesn.Sesn, *sesn.SesnCfg, error) {
@@ -131,4 +132,10 @@ func (s *BleSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 
 func (s *BleSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
 	return s.Ns.Filters()
+}
+
+func (s *BleSesn) SetFilters(txFilter nmcoap.MsgFilter,
+	rxFilter nmcoap.MsgFilter) {
+
+	s.Ns.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/nmcoap/frag.go
+++ b/nmxact/nmcoap/frag.go
@@ -20,8 +20,8 @@
 package nmcoap
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/runtimeco/go-coap"
+	log "github.com/sirupsen/logrus"
 )
 
 type Reassembler struct {
@@ -40,6 +40,7 @@ func (r *Reassembler) RxFrag(frag []byte) *coap.TcpMessage {
 	tm, r.cur, err = coap.PullTcp(r.cur)
 	if err != nil {
 		log.Debugf("received invalid CoAP-TCP packet: %s", err.Error())
+		panic("GA")
 		return nil
 	}
 

--- a/nmxact/nmcoap/listener.go
+++ b/nmxact/nmcoap/listener.go
@@ -1,0 +1,151 @@
+package nmcoap
+
+import (
+	"bytes"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/runtimeco/go-coap"
+)
+
+type MsgCriteria struct {
+	Token []byte
+	Path  string
+}
+
+type Listener struct {
+	Criteria MsgCriteria
+	RspChan  chan coap.Message
+	ErrChan  chan error
+	//StopChan chan struct{}
+	tmoChan chan time.Time
+	timer   *time.Timer
+}
+
+func (mc *MsgCriteria) String() string {
+	s := "token="
+	if mc.Token == nil {
+		s += "nil"
+	} else {
+		s += hex.EncodeToString(mc.Token)
+	}
+
+	s += " path="
+	if mc.Path == "" {
+		s += "nil"
+	} else {
+		s += mc.Path
+	}
+
+	return s
+}
+
+func CompareMsgCriteria(mc1 MsgCriteria, mc2 MsgCriteria) int {
+	// First sort key: path.
+	if diff := strings.Compare(mc1.Path, mc2.Path); diff != 0 {
+		return diff
+	}
+
+	// Second sort key: token.
+	if mc1.Token == nil && mc2.Token != nil {
+		return -1
+	}
+
+	if mc1.Token != nil && mc2.Token == nil {
+		return 1
+	}
+
+	if mc1.Token != nil {
+		if diff := bytes.Compare(mc1.Token, mc2.Token); diff != 0 {
+			return diff
+		}
+	}
+
+	return 0
+}
+
+// Determines if a listener matches an incoming message.
+func MatchMsgCriteria(listenc MsgCriteria, msgc MsgCriteria) bool {
+	// First sort key: path.
+	if listenc.Path != "" && listenc.Path != msgc.Path {
+		return false
+	}
+
+	// Second sort key: token.
+	if listenc.Token != nil {
+		if msgc.Token == nil {
+			return false
+		}
+
+		if bytes.Compare(listenc.Token, msgc.Token) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func CriteriaFromMsg(msg coap.Message) MsgCriteria {
+	return MsgCriteria{
+		Token: msg.Token(),
+		Path:  msg.PathString(),
+	}
+}
+
+func NewListener(mc MsgCriteria) *Listener {
+	return &Listener{
+		Criteria: mc,
+		RspChan:  make(chan coap.Message, 1),
+		ErrChan:  make(chan error, 1),
+		tmoChan:  make(chan time.Time, 1),
+	}
+}
+
+func (ol *Listener) AfterTimeout(tmo time.Duration) <-chan time.Time {
+	fn := func() {
+		if ol.tmoChan != nil {
+			ol.tmoChan <- time.Now()
+		}
+	}
+	ol.timer = time.AfterFunc(tmo, fn)
+	return ol.tmoChan
+}
+
+func (ol *Listener) Close() {
+	if ol.timer != nil {
+		ol.timer.Stop()
+	}
+
+	close(ol.RspChan)
+	close(ol.ErrChan)
+	close(ol.tmoChan)
+	ol.tmoChan = nil
+}
+
+type listenerSorter struct {
+	listeners []*Listener
+}
+
+func (s listenerSorter) Len() int {
+	return len(s.listeners)
+}
+func (s listenerSorter) Swap(i, j int) {
+	s.listeners[i], s.listeners[j] = s.listeners[j], s.listeners[i]
+}
+func (s listenerSorter) Less(i, j int) bool {
+	li := s.listeners[i]
+	lj := s.listeners[j]
+
+	return CompareMsgCriteria(li.Criteria, lj.Criteria) < 0
+}
+
+func SortListeners(listeners []*Listener) {
+	sorter := listenerSorter{
+		listeners: listeners,
+	}
+
+	// Reverse the sort order; most specific must come first.
+	sort.Sort(sort.Reverse(sorter))
+}

--- a/nmxact/nmp/nmp.go
+++ b/nmxact/nmp/nmp.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ugorji/go/codec"
 
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
-	"mynewt.apache.org/newt/util"
 )
 
 const NMP_HDR_SIZE = 8
@@ -87,8 +86,8 @@ func NewNmpMsg() *NmpMsg {
 
 func DecodeNmpHdr(data []byte) (*NmpHdr, error) {
 	if len(data) < NMP_HDR_SIZE {
-		return nil, util.NewNewtError(fmt.Sprintf(
-			"Newtmgr request buffer too small %d bytes", len(data)))
+		return nil, fmt.Errorf(
+			"Newtmgr request buffer too small %d bytes", len(data))
 	}
 
 	hdr := &NmpHdr{}

--- a/nmxact/nmxutil/nmxutil.go
+++ b/nmxact/nmxutil/nmxutil.go
@@ -190,14 +190,14 @@ func LogRemoveNmpListener(parentLevel int, seq uint8) {
 	LogListener(parentLevel, "remove-nmp-listener", fmt.Sprintf("seq=%d", seq))
 }
 
-func LogAddOicListener(parentLevel int, token []byte) {
+func LogAddOicListener(parentLevel int, desc string) {
 	LogListener(parentLevel, "add-oic-listener",
-		fmt.Sprintf("token=%+v", token))
+		fmt.Sprintf("desc=%s", desc))
 }
 
-func LogRemoveOicListener(parentLevel int, token []byte) {
+func LogRemoveOicListener(parentLevel int, desc string) {
 	LogListener(parentLevel, "remove-oic-listener",
-		fmt.Sprintf("token=%+v", token))
+		fmt.Sprintf("desc=%s", desc))
 }
 
 func LogAddListener(parentLevel int, key interface{}, id uint32,

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -23,9 +23,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/fatih/structs"
 	"github.com/runtimeco/go-coap"
+	log "github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
@@ -42,7 +42,7 @@ type OicMsg struct {
 }
 
 /*
- * Not able to install custom decoder for indefite length objects with the
+ * Not able to install custom decoder for indefinite length objects with the
  * codec.  So we need to decode the whole response, and then re-encode the
  * newtmgr response part.
  */

--- a/nmxact/xact/res.go
+++ b/nmxact/xact/res.go
@@ -22,194 +22,78 @@ package xact
 import (
 	"github.com/runtimeco/go-coap"
 
+	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/sesn"
 )
 
-type GetResCmd struct {
+type ResCmd struct {
 	CmdBase
-	Path       string
-	Observe    int
-	NotifyFunc sesn.GetNotifyCb
-	StopSignal chan int
-	Token      []byte
+	MsgParams nmcoap.MsgParams
 }
 
-func NewGetResCmd() *GetResCmd {
-	return &GetResCmd{
+func NewResCmd() *ResCmd {
+	return &ResCmd{
 		CmdBase: NewCmdBase(),
-		Observe: -1,
 	}
 }
 
-type GetResResult struct {
-	Code  coap.COAPCode
-	Value []byte
-	Token []byte
+type ResResult struct {
+	Rsp coap.Message
 }
 
-func newGetResResult() *GetResResult {
-	return &GetResResult{}
+func newResResult() *ResResult {
+	return &ResResult{}
 }
 
-func (r *GetResResult) Status() int {
-	if r.Code == coap.Content {
+func (r *ResResult) Status() int {
+	if r.Rsp.Code() == coap.Content {
 		return 0
 	} else {
-		return int(r.Code)
+		return int(r.Rsp.Code())
 	}
 }
 
-func (c *GetResCmd) Run(s sesn.Sesn) (Result, error) {
-	var status coap.COAPCode
-	var val []byte
-	var token []byte
+func (c *ResCmd) Run(s sesn.Sesn) (Result, error) {
+	var rsp coap.Message
 	var err error
 
-	if c.Observe != -1 {
-		status, val, token, err = sesn.GetResourceObserve(
-			s, c.Path, c.TxOptions(), c.NotifyFunc, c.StopSignal, c.Observe,
-			c.Token)
-	} else {
-		status, val, err = sesn.GetResource(s, c.Path, c.TxOptions())
-	}
-
+	rsp, err = sesn.TxRxCoap(s, c.MsgParams, c.txOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	res := newGetResResult()
-	res.Code = status
-	res.Value = val
-	res.Token = token
+	res := newResResult()
+	res.Rsp = rsp
 
 	return res, nil
 }
 
-type PutResCmd struct {
+type ResNoRxCmd struct {
 	CmdBase
-	Path  string
-	Value []byte
+	MsgParams nmcoap.MsgParams
 }
 
-func NewPutResCmd() *PutResCmd {
-	return &PutResCmd{
+func NewResNoRxCmd() *ResNoRxCmd {
+	return &ResNoRxCmd{
 		CmdBase: NewCmdBase(),
 	}
 }
 
-type PutResResult struct {
-	Code  coap.COAPCode
-	Value []byte
+type ResNoRxResult struct {
 }
 
-func newPutResResult() *PutResResult {
-	return &PutResResult{}
+func newResNoRxResult() *ResNoRxResult {
+	return &ResNoRxResult{}
 }
 
-func (r *PutResResult) Status() int {
-	if r.Code == coap.Created ||
-		r.Code == coap.Changed ||
-		r.Code == coap.Content {
-
-		return 0
-	} else {
-		return int(r.Code)
-	}
+func (r *ResNoRxResult) Status() int {
+	return 0
 }
 
-func (c *PutResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, r, err := sesn.PutResource(s, c.Path, c.Value, c.TxOptions())
-	if err != nil {
+func (c *ResNoRxCmd) Run(s sesn.Sesn) (Result, error) {
+	if err := sesn.TxCoap(s, c.MsgParams); err != nil {
 		return nil, err
 	}
 
-	res := newPutResResult()
-	res.Code = status
-	res.Value = r
-	return res, nil
-}
-
-type PostResCmd struct {
-	CmdBase
-	Path  string
-	Value []byte
-}
-
-func NewPostResCmd() *PostResCmd {
-	return &PostResCmd{
-		CmdBase: NewCmdBase(),
-	}
-}
-
-type PostResResult struct {
-	Code  coap.COAPCode
-	Value []byte
-}
-
-func newPostResResult() *PostResResult {
-	return &PostResResult{}
-}
-
-func (r *PostResResult) Status() int {
-	if r.Code == coap.Created ||
-		r.Code == coap.Changed ||
-		r.Code == coap.Content {
-
-		return 0
-	} else {
-		return int(r.Code)
-	}
-}
-
-func (c *PostResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, r, err := sesn.PostResource(s, c.Path, c.Value, c.TxOptions())
-	if err != nil {
-		return nil, err
-	}
-
-	res := newPostResResult()
-	res.Code = status
-	res.Value = r
-	return res, nil
-}
-
-type DeleteResCmd struct {
-	CmdBase
-	Path  string
-	Value []byte
-}
-
-func NewDeleteResCmd() *DeleteResCmd {
-	return &DeleteResCmd{
-		CmdBase: NewCmdBase(),
-	}
-}
-
-type DeleteResResult struct {
-	Code  coap.COAPCode
-	Value []byte
-}
-
-func newDeleteResResult() *DeleteResResult {
-	return &DeleteResResult{}
-}
-
-func (r *DeleteResResult) Status() int {
-	if r.Code == coap.Deleted {
-		return 0
-	} else {
-		return int(r.Code)
-	}
-}
-
-func (c *DeleteResCmd) Run(s sesn.Sesn) (Result, error) {
-	status, val, err := sesn.DeleteResource(s, c.Path, c.Value, c.TxOptions())
-	if err != nil {
-		return nil, err
-	}
-
-	res := newDeleteResResult()
-	res.Code = status
-	res.Value = val
-	return res, nil
+	return newResNoRxResult(), nil
 }

--- a/nmxact/xact/xact.go
+++ b/nmxact/xact/xact.go
@@ -38,7 +38,7 @@ func txReq(s sesn.Sesn, m *nmp.NmpMsg, c *CmdBase) (
 		c.curSesn = nil
 	}()
 
-	rsp, err := sesn.TxNmp(s, m, c.TxOptions())
+	rsp, err := sesn.TxRxMgmt(s, m, c.TxOptions())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a massive PR.

This PR changes the CoAP functions in the `sesn` interface.  In particular, it replaces the old API with three low-level functions:

```
    // Creates a listener for incoming CoAP messages matching the
    // specified criteria.
    ListenCoap(mc nmcoap.MsgCriteria) (*nmcoap.Listener, error)

    // Cancels the CoAP listener with the specified criteria.
    StopListenCoap(mc nmcoap.MsgCriteria)

    // Transmits a CoAP message.
    TxCoap(m coap.Message) error
```

Helper functions that combine these operations in useful ways are implemented in `sesn/sesn_util.go`.

Prior to this change, `sesn` contained only two CoAP functions:

```
    TxCoapOnce(m coap.Message,
        opt TxOptions) (coap.COAPCode, []byte, error)

    TxCoapObserve(m coap.Message, opt TxOptions, NotifCb GetNotifyCb,
        stopsignal chan int) (coap.COAPCode, []byte, []byte, error)
```

Both of these functions performed transmit followed by a blocking receive.  There were two issues with these functions:

1. Lots of duplicated logic in each `sesn` implementation.
2. Some forms of application layer security are not possible.

Re: 2- for example, say secure notifications are implemented as follows:

> Notification is encrypted and wrapped in a second, unencrypted, CoAP notification.  The outer message always specifies the same resource and has an indeterminate token.

To receive these notifications, the application needs to set up a permanent listener for the secure resource.  This listener needs to be created independently; it should not be paired with a transmit operation.  To make this possible, the "listen" operation needs to be a standalone function.

More generally, an interface with low level functions leads to less code duplication and a better design.