### PR TITLE
nmxact: Don't require serial session to "unlisten"

### DIFF
--- a/nmxact/nmcoap/listener.go
+++ b/nmxact/nmcoap/listener.go
@@ -75,10 +75,6 @@ func MatchMsgCriteria(listenc MsgCriteria, msgc MsgCriteria) bool {
 
 	// Second sort key: token.
 	if listenc.Token != nil {
-		if msgc.Token == nil {
-			return false
-		}
-
 		if bytes.Compare(listenc.Token, msgc.Token) != 0 {
 			return false
 		}

--- a/nmxact/nmserial/serial_xport.go
+++ b/nmxact/nmserial/serial_xport.go
@@ -29,9 +29,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/joaojeronimo/go-crc16"
 	"github.com/runtimeco/go-coap"
+	log "github.com/sirupsen/logrus"
 	"github.com/tarm/serial"
 
 	"mynewt.apache.org/newt/util"
@@ -188,9 +188,10 @@ func (sx *SerialXport) setRspSesn(s *SerialSesn) error {
 	if sx.closing {
 		return fmt.Errorf("Transport closed")
 	}
-	if s != nil && sx.rspSesn != nil {
+	if s != nil && sx.rspSesn != nil && s != sx.rspSesn {
 		return fmt.Errorf("Transport busy")
 	}
+
 	sx.rspSesn = s
 	return nil
 }


### PR DESCRIPTION
There is a max of one active session per serial transport.  This limitation is necessary because there is no demuxing protocol.  Whatever data is received over serial is just forwarded to the active session.

Before this commit, nmxact required the active sesion to unregister itself before any session could be registered again, even if the two sessions are the same.

This commit relaxes this restriction.  Now, it is OK to register the same session multiple times without unregistering in between.

This change is necessary due to the recent change to the session API.  Now, listening and transmitting are separate operations, so it is not trivial to arrange for a session to be unregistered after use.  In practice, there is never more than one serial session anyway.