### PR TITLE
newtmgr/cli/interactive.go: fix ishell import

### DIFF
--- a/newtmgr/cli/interactive.go
+++ b/newtmgr/cli/interactive.go
@@ -29,7 +29,7 @@ import (
 	"github.com/runtimeco/go-coap"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"gopkg.in/abiosoft/ishell.v1"
+	"github.com/abiosoft/ishell"
 	"mynewt.apache.org/newtmgr/newtmgr/nmutil"
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmxutil"


### PR DESCRIPTION
fixes [issue 8 in mcumgr-cli.](https://github.com/apache/mynewt-mcumgr-cli/issues/8)

Signed-off-by: Connor "SIGSTACKFAULT" King <SIGSTACKFAULT@gmail.com>