### PR TITLE
nmxact: Create a listener for each OMP response

### DIFF
--- a/nmxact/mgmt/transceiver.go
+++ b/nmxact/mgmt/transceiver.go
@@ -192,7 +192,7 @@ func (t *Transceiver) ListenCoap(
 
 	mc.Path = strings.TrimPrefix(mc.Path, "/")
 
-	ol, err := t.od.AddOicListener(mc)
+	ol, err := t.od.AddCoapListener(mc)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (t *Transceiver) ListenCoap(
 
 func (t *Transceiver) StopListenCoap(mc nmcoap.MsgCriteria) {
 	mc.Path = strings.TrimPrefix(mc.Path, "/")
-	t.od.RemoveOicListener(mc)
+	t.od.RemoveCoapListener(mc)
 }
 
 func (t *Transceiver) DispatchNmpRsp(data []byte) {

--- a/nmxact/nmcoap/dispatch.go
+++ b/nmxact/nmcoap/dispatch.go
@@ -68,7 +68,7 @@ func (d *Dispatcher) matchListener(mc MsgCriteria) *Listener {
 }
 
 func (d *Dispatcher) AddListener(mc MsgCriteria) (*Listener, error) {
-	nmxutil.LogAddOicListener(d.logDepth, mc.String())
+	nmxutil.LogAddCoapListener(d.logDepth, mc.String())
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
@@ -96,7 +96,7 @@ func (d *Dispatcher) RemoveListener(mc MsgCriteria) *Listener {
 
 	d.listeners = append(d.listeners[:idx], d.listeners[idx+1:]...)
 
-	nmxutil.LogRemoveOicListener(d.logDepth, mc.String())
+	nmxutil.LogRemoveCoapListener(d.logDepth, mc.String())
 	lner.Close()
 
 	return lner

--- a/nmxact/nmcoap/listener.go
+++ b/nmxact/nmcoap/listener.go
@@ -19,9 +19,8 @@ type Listener struct {
 	Criteria MsgCriteria
 	RspChan  chan coap.Message
 	ErrChan  chan error
-	//StopChan chan struct{}
-	tmoChan chan time.Time
-	timer   *time.Timer
+	tmoChan  chan time.Time
+	timer    *time.Timer
 }
 
 func (mc *MsgCriteria) String() string {

--- a/nmxact/nmxutil/nmxutil.go
+++ b/nmxact/nmxutil/nmxutil.go
@@ -190,12 +190,12 @@ func LogRemoveNmpListener(parentLevel int, seq uint8) {
 	LogListener(parentLevel, "remove-nmp-listener", fmt.Sprintf("seq=%d", seq))
 }
 
-func LogAddOicListener(parentLevel int, desc string) {
+func LogAddCoapListener(parentLevel int, desc string) {
 	LogListener(parentLevel, "add-oic-listener",
 		fmt.Sprintf("desc=%s", desc))
 }
 
-func LogRemoveOicListener(parentLevel int, desc string) {
+func LogRemoveCoapListener(parentLevel int, desc string) {
 	LogListener(parentLevel, "remove-oic-listener",
 		fmt.Sprintf("desc=%s", desc))
 }

--- a/nmxact/omp/dispatch.go
+++ b/nmxact/omp/dispatch.go
@@ -20,96 +20,119 @@
 package omp
 
 import (
+	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/runtimeco/go-coap"
-	log "github.com/sirupsen/logrus"
 
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
 	"mynewt.apache.org/newtmgr/nmxact/nmp"
+	"mynewt.apache.org/newtmgr/nmxact/nmxutil"
 )
+
+type Listener struct {
+	nmpl   *nmp.Listener
+	coapl  *nmcoap.Listener
+	stopCh chan struct{}
+}
 
 // The dispatcher is the owner of the listeners it points to.  Only the
 // dispatcher writes to these listeners.
 type Dispatcher struct {
-	nmpd     *nmp.Dispatcher
-	coapd    *nmcoap.Dispatcher
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
-	rxFilter nmcoap.MsgFilter
-	stopped  uint32
+	seqListenerMap map[uint8]*Listener
+	coapd          *nmcoap.Dispatcher
+	wg             sync.WaitGroup
+	rxFilter       nmcoap.MsgFilter
+	stopped        bool
+	logDepth       int
+	mtx            sync.Mutex
 }
 
 func NewDispatcher(rxFilter nmcoap.MsgFilter, isTcp bool,
 	logDepth int) (*Dispatcher, error) {
 
 	d := &Dispatcher{
-		nmpd:     nmp.NewDispatcher(logDepth + 1),
-		coapd:    nmcoap.NewDispatcher(isTcp, logDepth+1),
-		stopCh:   make(chan struct{}),
-		rxFilter: rxFilter,
-	}
-
-	// Listen for OMP responses.  This should never fail.
-	if err := d.addOmpListener(); err != nil {
-		log.Errorf("Unexpected failure to add OMP listener: " + err.Error())
-		return nil, err
+		seqListenerMap: map[uint8]*Listener{},
+		coapd:          nmcoap.NewDispatcher(isTcp, logDepth+1),
+		rxFilter:       rxFilter,
+		logDepth:       logDepth + 2,
 	}
 
 	return d, nil
 }
 
-func (d *Dispatcher) addOmpListener() error {
-	// OMP responses are identifiable by the lack of a CoAP token.  Set up a
-	// permanent listener to receive these messages.
+func (d *Dispatcher) addOmpListener(seq uint8) (*Listener, error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	if d.seqListenerMap[seq] != nil {
+		return nil, fmt.Errorf("duplicate OMP listener; seq=%d", seq)
+	}
+
 	mc := nmcoap.MsgCriteria{
-		Token: []byte{},
+		Token: nmxutil.SeqToToken(seq),
 		Path:  "",
 	}
 
 	ol, err := d.AddCoapListener(mc)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	ompl := &Listener{
+		nmpl:   nmp.NewListener(),
+		coapl:  ol,
+		stopCh: make(chan struct{}),
+	}
+	d.seqListenerMap[seq] = ompl
 
 	d.wg.Add(1)
 	go func() {
 		defer d.RemoveCoapListener(mc)
 		defer d.wg.Done()
 
+		// Listen for events.  All feedback is sent to the client via the NMP
+		// listener channels.  It is done this way so that client code can be
+		// OMP/NMP agnostic.
 		for {
 			select {
-			case m := <-ol.RspChan:
+			case m := <-ompl.coapl.RspChan:
 				rsp, err := DecodeOmp(m, d.rxFilter)
 				if err != nil {
-					log.Debugf("OMP decode failure: %s", err.Error())
+					ompl.nmpl.ErrChan <- err
 				} else if rsp != nil {
-					d.nmpd.DispatchRsp(rsp)
+					ompl.nmpl.RspChan <- rsp
 				} else {
 					/* no error, no response */
 				}
 
-			case err := <-ol.ErrChan:
+			case err := <-ompl.coapl.ErrChan:
 				if err != nil {
-					log.Debugf("OIC error: %s", err.Error())
+					ompl.nmpl.ErrChan <- err
 				}
 
-			case <-d.stopCh:
+			case <-ompl.stopCh:
 				return
 			}
 		}
 	}()
 
-	return nil
+	return ompl, nil
 }
 
 func (d *Dispatcher) Stop() {
-	if !atomic.CompareAndSwapUint32(&d.stopped, 0, 1) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	if d.stopped {
 		return
 	}
+	d.stopped = true
 
-	close(d.stopCh)
+	for seq, ompl := range d.seqListenerMap {
+		delete(d.seqListenerMap, seq)
+		close(ompl.stopCh)
+	}
 	d.wg.Wait()
 }
 
@@ -121,32 +144,56 @@ func (d *Dispatcher) ProcessCoapReq(data []byte) (coap.Message, error) {
 	return d.coapd.ProcessCoapReq(data)
 }
 
-func (d *Dispatcher) AddOicListener(
+func (d *Dispatcher) AddCoapListener(
 	mc nmcoap.MsgCriteria) (*nmcoap.Listener, error) {
 
 	return d.coapd.AddListener(mc)
 }
 
-func (d *Dispatcher) RemoveOicListener(
+func (d *Dispatcher) RemoveCoapListener(
 	mc nmcoap.MsgCriteria) *nmcoap.Listener {
 
 	return d.coapd.RemoveListener(mc)
 }
 
 func (d *Dispatcher) AddNmpListener(seq uint8) (*nmp.Listener, error) {
-	return d.nmpd.AddListener(seq)
+	ompl, err := d.addOmpListener(seq)
+	if err != nil {
+		return nil, err
+	}
+
+	nmxutil.LogAddNmpListener(d.logDepth, seq)
+	return ompl.nmpl, nil
 }
 
 func (d *Dispatcher) RemoveNmpListener(seq uint8) *nmp.Listener {
-	return d.nmpd.RemoveListener(seq)
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	ompl := d.seqListenerMap[seq]
+	if ompl != nil {
+		delete(d.seqListenerMap, seq)
+		close(ompl.stopCh)
+	}
+
+	nmxutil.LogRemoveNmpListener(d.logDepth, seq)
+	return ompl.nmpl
 }
 
 func (d *Dispatcher) ErrorOneNmp(seq uint8, err error) error {
-	return d.nmpd.ErrorOne(seq, err)
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	ompl := d.seqListenerMap[seq]
+	if ompl == nil {
+		return fmt.Errorf("no nmp listener for seq %d", seq)
+	}
+
+	ompl.nmpl.ErrChan <- err
+	return nil
 }
 
 func (d *Dispatcher) ErrorAll(err error) {
-	d.nmpd.ErrorAll(err)
 	d.coapd.ErrorAll(err)
 }
 

--- a/nmxact/omp/dispatch.go
+++ b/nmxact/omp/dispatch.go
@@ -68,14 +68,14 @@ func (d *Dispatcher) addOmpListener() error {
 		Path:  "",
 	}
 
-	ol, err := d.AddOicListener(mc)
+	ol, err := d.AddCoapListener(mc)
 	if err != nil {
 		return err
 	}
 
 	d.wg.Add(1)
 	go func() {
-		defer d.RemoveOicListener(mc)
+		defer d.RemoveCoapListener(mc)
 		defer d.wg.Done()
 
 		for {

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -105,8 +105,9 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 	er := encodeRecord{}
 
 	mp := coap.MessageParams{
-		Type: coap.Confirmable,
-		Code: coap.PUT,
+		Type:  coap.Confirmable,
+		Code:  coap.PUT,
+		Token: nmxutil.SeqToToken(nmr.Hdr.Seq),
 	}
 
 	if isTcp {


### PR DESCRIPTION
Prior to this change, nmxact created a single CoAP listener to handle all incoming OMP responses.  This listener would parse the embedded NMP message, then dispatch to the appropriate NMP listener based on the NMP sequence number.

There is a problem with this approach.  If the server rejects an outgoing OMP request with a CoAP error (e.g., the omp resource requires a more secure connection), then the error does not get passed up to the caller.  The error response does not contain an embedded NMP response, so there is no way to match it with the appropriate listener.  The result is that nmxact drops the CoAP error, and the OMP operation eventually times out.

This PR makes the following changes:
* Every outgoing OMP request contains a single-byte token consisting of the NMP sequence number.
* A new CoAP listener and NMP listener are created for each expected OMP response.
* Both NMP errors and CoAP errors are communicated to the caller.

With this change, when an OMP elicits a CoAP error, newtmgr displays the error and terminates.  