### PR TITLE
Include imghash in log show output

### DIFF
--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -107,9 +107,9 @@ func logShowCmd(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		fmt.Printf("%10s %22s | %16s %16s %6s %s\n",
+		fmt.Printf("%10s %22s | %16s %16s %6s %8s %s\n",
 			"[index]", "[timestamp]", "[module]", "[level]", "[type]",
-			"[message]")
+			"[img]", "[message]")
 		for _, entry := range log.Entries {
 			modText := fmt.Sprintf("%s (%d)",
 				nmp.LogModuleToString(int(entry.Module)), entry.Module)
@@ -138,14 +138,15 @@ func logShowCmd(cmd *cobra.Command, args []string) {
 					int(entry.Type), entry.Index)
 				msgText = hex.EncodeToString(entry.Msg)
 			}
-			fmt.Printf("%10d %20dus | %16s %16s %6s %s\n",
+
+			fmt.Printf("%10d %20dus | %16s %16s %6s %8s %s\n",
 				entry.Index,
 				entry.Timestamp,
 				modText,
 				levText,
 				entry.Type,
+				hex.EncodeToString(entry.ImgHash),
 				msgText)
-
 		}
 	}
 }
@@ -327,5 +328,6 @@ func logCmd() *cobra.Command {
 	}
 
 	logCmd.AddCommand(ListCmd)
+
 	return logCmd
 }

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -135,6 +135,7 @@ type LogEntry struct {
 	Module    uint8        `codec:"module"`
 	Level     uint8        `codec:"level"`
 	Type      LogEntryType `codec:"type"`
+	ImgHash   []byte       `codec:"imghash"`
 	Msg       []byte       `codec:"msg"`
 }
 


### PR DESCRIPTION
The Mynewt log entry header optionally includes an "imghash" field. This field contains a truncated hash of the build that was running when the entry was logged.  If an entry contains this hash, the Mynewt device includes it in a `log show` response.

This PR changes newtmgr to print the image hash when it sees it in a `log show` response.