### PR TITLE
README: Indicate that GO111MODULE must be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Build the newtmgr tool as follows:
 1. Unpack newtmgr source.
 2. Rename resulting `apache-mynewt-newtmgr-1.3.0` directory to `$GOPATH/src/mynewt.apache.org/newtmgr`
 3. `cd $GOPATH/src/mynewt.apache.org/newtmgr/newtmgr`
-4. `go build`
+4. `GO111MODULE=on go build`

--- a/docs/install/install_linux.rst
+++ b/docs/install/install_linux.rst
@@ -185,7 +185,7 @@ install the latest release version of newtmgr from source.
    .. code-block:: console
 
       $ cd newtmgr
-      $ go install
+      $ GO111MODULE=on go install
       $ ls /tmp/go/bin/newtmgr
       -rwxr-xr-x  1 user  staff  17888680 Jul 29 16:28 /tmp/go/bin/newtmgr
 

--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -110,7 +110,7 @@ build and install the latest release version of newtmgr from source.
    .. code-block:: console
 
       $ cd newtmgr
-      $ go install
+      $ GO111MODULE=on go install
       $ ls /tmp/go/bin/newtmgr.exe
       -rwxr-xr-x 1 user None 15457280 Sep 12 00:30 /tmp/go/bin/newtmgr.exe
 


### PR DESCRIPTION
Now that newtmgr uses modules instead of a vendor directory, module support needs to be enabled to build newtmgr.

This setting is only necessary for older versions of go.  In newer versions, the setting is enabled by default (outside of the GOPATH). Maybe we can revert this change once modules become fully mainstream.