### PR TITLE
[RFC] Add basic multi-image support

### DIFF
--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -44,6 +44,7 @@ var (
 
 var noerase bool
 var upgrade bool
+var imageNum int
 
 func imageFlagsStr(image nmp.ImageStateEntry) string {
 	strs := []string{}
@@ -71,7 +72,7 @@ func imageStatePrintRsp(rsp *nmp.ImageStateRsp) error {
 	}
 	fmt.Println("Images:")
 	for _, img := range rsp.Images {
-		fmt.Printf(" slot=%d\n", img.Slot)
+		fmt.Printf(" image=%d slot=%d\n", img.Image, img.Slot)
 		fmt.Printf("    version: %s\n", img.Version)
 		fmt.Printf("    bootable: %v\n", img.Bootable)
 		fmt.Printf("    flags: %s\n", imageFlagsStr(img))
@@ -190,6 +191,10 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 	if noerase == true {
 		c.NoErase = true
 	}
+	if imageNum < 0 {
+		nmUsage(cmd, util.NewNewtError("Invalid image number"))
+	}
+	c.ImageNum = imageNum
 	c.Upgrade = upgrade
 	c.ProgressBar = pb.StartNew(len(imageFile))
 	c.ProgressBar.SetUnits(pb.U_BYTES)
@@ -403,6 +408,9 @@ func imageCmd() *cobra.Command {
 		"upgrade", "u", false,
 		"Only allow the upload if the new image's version is greater than "+
 			"that of the currently running image")
+	uploadCmd.PersistentFlags().IntVarP(&imageNum,
+		"image", "n", 0,
+		"In a multi-image system, which image should be uploaded")
 	imageCmd.AddCommand(uploadCmd)
 
 	coreListCmd := &cobra.Command{

--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -24,12 +24,13 @@ package nmp
 //////////////////////////////////////////////////////////////////////////////
 
 type ImageUploadReq struct {
-	NmpBase `codec:"-"`
-	Off     uint32 `codec:"off"`
-	Len     uint32 `codec:"len,omitempty"`
-	DataSha []byte `codec:"sha,omitempty"`
-	Upgrade bool   `codec:"upgrade,omitempty"`
-	Data    []byte `codec:"data"`
+	NmpBase  `codec:"-"`
+	ImageNum uint8  `codec:"image"`
+	Off      uint32 `codec:"off"`
+	Len      uint32 `codec:"len,omitempty"`
+	DataSha  []byte `codec:"sha,omitempty"`
+	Upgrade  bool   `codec:"upgrade,omitempty"`
+	Data     []byte `codec:"data"`
 }
 
 type ImageUploadRsp struct {
@@ -81,6 +82,7 @@ func (sm SplitStatus) String() string {
 
 type ImageStateEntry struct {
 	NmpBase
+	Image     int    `codec:"image"`
 	Slot      int    `codec:"slot"`
 	Version   string `codec:"version"`
 	Hash      []byte `codec:"hash"`


### PR DESCRIPTION
This makes `image list` and `image upload` compatible with MCUBoot's `serial_boot` when working in a multi-image setting.

The image state CBOR packet and image upload were both update to carry an extra field called "image" whose number indicates which image set is being handled. If absent, image 0 is used for compatibility.

The upload command got and extra parameter `-n` (or `--image`) to set which image is being sent, eg, `newtmgr image -n1 upload <fw.img>`.

The image list command now prints "image=X slot=Y", eg:

```
Images:
 image=0 slot=0
    version: 1.7.0.0
    bootable: false
    flags:
    hash: Unavailable
 image=0 slot=1
    version: 1.4.0.0
    bootable: false
    flags:
    hash: Unavailable
 image=1 slot=0
    version: 1.8.0.0
    bootable: false
    flags:
    hash: Unavailable
Split status: N/A (0)
```