### PR TITLE
res: Don't include payload if none specified

### DIFF
--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -217,6 +217,11 @@ func parsePayload(args []string) ([]byte, error) {
 		return nil, err
 	}
 
+	if m == nil {
+		// No payload.
+		return nil, nil
+	}
+
 	b, err := nmxutil.EncodeCborMap(m)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If the user issues a `res` command with no payload (e.g., `res get /my/resource`), the outgoing command should not have a payload.

Instead, newtmgr was encoding an empty map as the payload.