### PR TITLE
res: Interpret all 2xx codes as success

### DIFF
--- a/nmxact/xact/res.go
+++ b/nmxact/xact/res.go
@@ -46,9 +46,11 @@ func newResResult() *ResResult {
 }
 
 func (r *ResResult) Status() int {
-	if r.Rsp.Code() == coap.Content {
+	switch r.Rsp.Code() {
+	case coap.Created, coap.Deleted, coap.Valid, coap.Changed, coap.Content:
 		return 0
-	} else {
+
+	default:
 		return int(r.Rsp.Code())
 	}
 }


### PR DESCRIPTION
Prior to this PR, only 2.05 (Content) was considered success.  All other 2xx codes (e.g., Created, Valid, etc.) were treated as failures.