### PR TITLE
omp: Don't dereference nil pointer

### DIFF
--- a/nmxact/omp/dispatch.go
+++ b/nmxact/omp/dispatch.go
@@ -171,10 +171,12 @@ func (d *Dispatcher) RemoveNmpListener(seq uint8) *nmp.Listener {
 	defer d.mtx.Unlock()
 
 	ompl := d.seqListenerMap[seq]
-	if ompl != nil {
-		delete(d.seqListenerMap, seq)
-		close(ompl.stopCh)
+	if ompl == nil {
+		return nil
 	}
+
+	delete(d.seqListenerMap, seq)
+	close(ompl.stopCh)
 
 	nmxutil.LogRemoveNmpListener(d.logDepth, seq)
 	return ompl.nmpl


### PR DESCRIPTION
This PR fixes this crash reported by @vrahane (note: paths obfuscated):
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4450e4f]
goroutine 1 [running]:
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/omp.(*Dispatcher).RemoveNmpListener(0xc0000c0700, 0x42, 0x0)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/omp/dispatch.go:180 +0xcf
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/mgmt.(*Transceiver).txRxOmp(0xc0000c06c0, 0xc000069080, 0xc00000e500, 0x1fd, 0x2540be400, 0x0, 0x0, 0x487b0a0, 0xc000298080)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/mgmt/transceiver.go:152 +0x4ef
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/mgmt.(*Transceiver).TxRxMgmt(0xc0000c06c0, 0xc000069080, 0xc00000e500, 0x1fd, 0x2540be400, 0xc00019a240, 0xc000000180, 0xc0000c0000, 0x400d909)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/mgmt/transceiver.go:169 +0xcc
<base>/vendor/mynewt.apache.org/newtmgr/newtmgr/bll.(*BllSesn).TxRxMgmt(0xc00019a240, 0xc00000e500, 0x2540be400, 0xc0002057e0, 0x402cabf, 0x8, 0xc0000c0000)
    <home-base>/vendor/mynewt.apache.org/newtmgr/newtmgr/bll/bll_sesn.go:392 +0x174
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/sesn.TxRxMgmt(0x4898060, 0xc00019a240, 0xc00000e500, 0x2540be400, 0x1, 0x20, 0x46e0c00, 0x42000400000001, 0xc00000e500)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/sesn/sesn_util.go:37 +0x69
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/xact.txReq(0x4898060, 0xc00019a240, 0xc00000e500, 0xc000205c08, 0x0, 0x0, 0x0, 0x0)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/xact/xact.go:41 +0xca
<base>/vendor/mynewt.apache.org/newtmgr/nmxact/xact.(*LogShowCmd).Run(0xc000205c08, 0x4898060, 0xc00019a240, 0x0, 0xc0000af170, 0x4787d23, 0x8)
    <home-base>/vendor/mynewt.apache.org/newtmgr/nmxact/xact/log.go:62 +0x118
<base>/vendor/mynewt.apache.org/newtmgr/newtmgr/cli.logShowCmd(0xc0001e9180, 0xc000194a10, 0x0, 0x7)
    <home-base>/vendor/mynewt.apache.org/newtmgr/newtmgr/cli/log.go:88 +0x22c
<base>/vendor/github.com/spf13/cobra.(*Command).execute(0xc0001e9180, 0xc00018c240, 0x7, 0xc, 0xc0001e9180, 0xc00018c240)
    <home-base>/vendor/github.com/spf13/cobra/command.go:830 +0x2ae
<base>/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000198280, 0xc0000ac5a0, 0x4783c40, 0x3)
    <home-base>/vendor/github.com/spf13/cobra/command.go:914 +0x2fc
<base>/vendor/github.com/spf13/cobra.(*Command).Execute(...)
    <home-base>/vendor/github.com/spf13/cobra/command.go:864
main.main()
    <home-base>/<...> +0x1e2
```