### PR TITLE
nmxact: Don't skip seq numbers in `image upload`

### DIFF
--- a/nmxact/nmp/image.go
+++ b/nmxact/nmp/image.go
@@ -45,6 +45,12 @@ func NewImageUploadReq() *ImageUploadReq {
 	return r
 }
 
+func NewImageUploadReqWithSeq(seq uint8) *ImageUploadReq {
+	r := &ImageUploadReq{}
+	fillNmpReqWithSeq(r, NMP_OP_WRITE, NMP_GROUP_IMAGE, NMP_ID_IMAGE_UPLOAD, seq)
+	return r
+}
+
 func (r *ImageUploadReq) Msg() *NmpMsg { return MsgFromReq(r) }
 
 func NewImageUploadRsp() *ImageUploadRsp {

--- a/nmxact/nmp/nmp.go
+++ b/nmxact/nmp/nmp.go
@@ -150,15 +150,19 @@ func EncodeNmpPlain(nmr *NmpMsg) ([]byte, error) {
 	return data, nil
 }
 
-func fillNmpReq(req NmpReq, op uint8, group uint16, id uint8) {
+func fillNmpReqWithSeq(req NmpReq, op uint8, group uint16, id uint8, seq uint8) {
 	hdr := NmpHdr{
 		Op:    op,
 		Flags: 0,
 		Len:   0,
 		Group: group,
-		Seq:   nmxutil.NextNmpSeq(),
+		Seq:   seq,
 		Id:    id,
 	}
 
 	req.SetHdr(&hdr)
+}
+
+func fillNmpReq(req NmpReq, op uint8, group uint16, id uint8) {
+	fillNmpReqWithSeq(req, op, group, id, nmxutil.NextNmpSeq())
 }

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -20,12 +20,10 @@
 package omp
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/fatih/structs"
 	"github.com/runtimeco/go-coap"
-	log "github.com/sirupsen/logrus"
 	"github.com/ugorji/go/codec"
 
 	"mynewt.apache.org/newtmgr/nmxact/nmcoap"
@@ -157,11 +155,6 @@ func EncodeOmpTcp(txFilterCb nmcoap.MsgFilter, nmr *nmp.NmpMsg) ([]byte, error) 
 		return nil, fmt.Errorf("Failed to encode: %s\n", err.Error())
 	}
 
-	log.Debugf("Serialized OMP TCP request:\n"+
-		"Hdr %+v:\n%s\nPayload:%s\nData:\n%s",
-		nmr.Hdr, hex.Dump(er.hdrBytes), hex.Dump(er.m.Payload()),
-		hex.Dump(data))
-
 	return data, nil
 }
 
@@ -175,11 +168,6 @@ func EncodeOmpDgram(txFilterCb nmcoap.MsgFilter, nmr *nmp.NmpMsg) ([]byte, error
 	if err != nil {
 		return nil, fmt.Errorf("Failed to encode: %s\n", err.Error())
 	}
-
-	log.Debugf("Serialized OMP datagram request:\n"+
-		"Hdr %+v:\n%s\nPayload:%s\nData:\n%s",
-		nmr.Hdr, hex.Dump(er.hdrBytes), hex.Dump(er.m.Payload()),
-		hex.Dump(data))
 
 	return data, nil
 }


### PR DESCRIPTION
nmxact generates several image upload requests for each one that it actually sends.  It does this to determine the ideal chunk size.

Each of these requests was consuming a sequence number.  As a result, the sequence number would increase by three for each request that was actually transmitted.

This PR changes the image upload command such that the sequence number is only increased when a request is actually sent.

This PR also removes the "Serialized OMP" debug log message.  This message got logged immediately before the request got transmitted.  The result was two nearly identical large log messages (both contain the full payload of the request).