### PR TITLE
res: When `-j` is specified, allow all value types 

### DIFF
--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -190,39 +190,39 @@ func parsePayloadMap(args []string) (map[string]interface{}, error) {
 	return m, nil
 }
 
-func parsePayloadJson(args []string) (map[string]interface{}, error) {
+func parsePayloadJson(args []string) (interface{}, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
 
-	var obj map[string]interface{}
+	var val interface{}
 
-	if err := json.Unmarshal([]byte(args[0]), &obj); err != nil {
+	if err := json.Unmarshal([]byte(args[0]), &val); err != nil {
 		return nil, util.ChildNewtError(err)
 	}
 
-	return obj, nil
+	return val, nil
 }
 
 func parsePayload(args []string) ([]byte, error) {
-	var m map[string]interface{}
+	var val interface{}
 	var err error
 
 	if resJson {
-		m, err = parsePayloadJson(args)
+		val, err = parsePayloadJson(args)
 	} else {
-		m, err = parsePayloadMap(args)
+		val, err = parsePayloadMap(args)
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	if m == nil {
+	if val == nil {
 		// No payload.
 		return nil, nil
 	}
 
-	b, err := nmxutil.EncodeCborMap(m)
+	b, err := nmxutil.EncodeCbor(val)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prior to this PR, `res -j` would only accept a `map[string]interface{}` as the payload.  Now, it accepts an `interface{}`.  This allows the payload to consist of a number, a string, or an array (or an object, as before).

Also:
JSON only supports a single numeric type: "number".  When the `res -j` command parses a payload, the JSON unmarshal function parses all numbers as instances of float64.  This makes the resulting CBOR payload incorrect when the user just wants to use integers.

This PR adds an option to the res command: `--int`.  When specified, all numbers in the payload are converted to integers when the conversion does not result in a change in value.  For example, `1.0` is converted to an integer, but `1.5` is not.