### PR TITLE
res: Use zero payload when no args specified

### DIFF
--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -255,27 +255,28 @@ func parsePayload(args []string) ([]byte, error) {
 	var val interface{}
 	var err error
 
+	if len(args) == 0 {
+		return nil, nil
+	}
+
 	if resJson {
-		if len(args) == 0 {
-			return nil, nil
-		}
-		itf, err := parsePayloadJson(args[0])
+		val, err = parsePayloadJson(args[0])
 		if err != nil {
 			return nil, err
 		}
 		// Check for zero payload.  Need to return nil explicitly; don't wrap
 		// in interface{}.
-		if itf == nil {
+		if val == nil {
 			return nil, nil
 		}
 	} else {
-		itf, err := parsePayloadMap(args)
+		val, err = parsePayloadMap(args)
 		if err != nil {
 			return nil, err
 		}
 		// Check for zero payload.  Need to return nil explicitly; don't wrap
 		// in interface{}.
-		if itf == nil {
+		if val == nil {
 			return nil, nil
 		}
 	}

--- a/newtmgr/cli/res.go
+++ b/newtmgr/cli/res.go
@@ -259,17 +259,25 @@ func parsePayload(args []string) ([]byte, error) {
 		if len(args) == 0 {
 			return nil, nil
 		}
-		val, err = parsePayloadJson(args[0])
+		itf, err := parsePayloadJson(args[0])
+		if err != nil {
+			return nil, err
+		}
+		// Check for zero payload.  Need to return nil explicitly; don't wrap
+		// in interface{}.
+		if itf == nil {
+			return nil, nil
+		}
 	} else {
-		val, err = parsePayloadMap(args)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	if val == nil {
-		// No payload.
-		return nil, nil
+		itf, err := parsePayloadMap(args)
+		if err != nil {
+			return nil, err
+		}
+		// Check for zero payload.  Need to return nil explicitly; don't wrap
+		// in interface{}.
+		if itf == nil {
+			return nil, nil
+		}
 	}
 
 	b, err := nmxutil.EncodeCbor(val)


### PR DESCRIPTION
This command:
```
    newtmgr res get /my/res
```
should send a CoAP GET request with *no* payload.  An optional payload can be specified with extra arguments after the resource name.  Since there are no extra arguments, there should be no payload.

Prior to this PR, newtmgr was including an empty map as the payload in such requests.

The bug was caused by this quirk in Go:
https://forum.golangbridge.org/t/a-nil-a-b-b-nil-with-pointers-and-interface/10593

In short, if `nil` is assigned to a variable of type `interface{}`, the variable will *not* compare equal to `nil`.  An interface variable contains two pieces of information: 1) its type, and 2) its value.  The variable is not equal to `nil` because `nil` is an *untyped* nil value.

The solution is to return the untyped `nil` rather than the nil interface{}.