### PR TITLE
Use latest ble library (with cbgo)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module mynewt.apache.org/newtmgr
 go 1.12
 
 require (
-	github.com/JuulLabs-OSS/ble v0.0.0-20200415235928-df3a9e6783a9
+	github.com/JuulLabs-OSS/ble v0.0.0-20200421174404-4a6a93a950fe
+	github.com/JuulLabs-OSS/cbgo v0.0.0-20200421065905-1762a9c3147c
 	github.com/abiosoft/ishell v2.0.0+incompatible // indirect
 	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db // indirect
 	github.com/cheggaaa/pb v2.0.7+incompatible // indirect
@@ -25,7 +26,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/raff/goble v0.0.0-20200327175727-d63360dcfd80 // indirect
 	github.com/runtimeco/go-coap v0.0.0-20190911184520-8e5532820fc0
-	github.com/sirupsen/logrus v1.4.2
+	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/JuulLabs-OSS/ble v0.0.0-20200415235928-df3a9e6783a9 h1:2VXy9m1Bl4unkc3ZcWUrwn/sv1uCoimg99wmFv4xoNE=
 github.com/JuulLabs-OSS/ble v0.0.0-20200415235928-df3a9e6783a9/go.mod h1:qMsm/vRFvBk32uWdeFzvSZ8xsw0DUopgJFRgxaYpzt4=
+github.com/JuulLabs-OSS/ble v0.0.0-20200421174404-4a6a93a950fe h1:YnTwo0OKGlHaI9LgmuJRdecE08aZ5q/xBKkKx6NGWlQ=
+github.com/JuulLabs-OSS/ble v0.0.0-20200421174404-4a6a93a950fe/go.mod h1:pfS28CC0m6k3HdEWztSfIpvKpn3Zsxu1jzuNJ3pnFNo=
+github.com/JuulLabs-OSS/cbgo v0.0.0-20200421065905-1762a9c3147c h1:CwwgT8zV4/uvoPQuRtGBt+aQwLL7zCV/ezGz0UdXp14=
+github.com/JuulLabs-OSS/cbgo v0.0.0-20200421065905-1762a9c3147c/go.mod h1:L4YtGP+gnyD84w7+jN66ncspFRfOYB5aj9QSXaFHmBA=
 github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:w5D10RxC0NmPYxmQ438CC1S07zaC1zpvuNW7s5sUk2Q=
 github.com/abiosoft/ishell v2.0.0+incompatible h1:zpwIuEHc37EzrsIYah3cpevrIc8Oma7oZPxr03tlmmw=
 github.com/abiosoft/ishell v2.0.0+incompatible/go.mod h1:HQR9AqF2R3P4XXpMpI0NAzgHf/aS6+zVXRj14cVk9qg=
@@ -139,6 +143,8 @@ github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=

--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -39,7 +39,8 @@ func Commands() *cobra.Command {
 		Use:   nmutil.ToolInfo.ExeName,
 		Short: nmutil.ToolInfo.ShortName + " helps you manage remote devices",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			NewtmgrLogLevel, err := log.ParseLevel(logLevelStr)
+			var err error
+			NewtmgrLogLevel, err = log.ParseLevel(logLevelStr)
 			if err != nil {
 				nmUsage(nil, util.ChildNewtError(err))
 			}
@@ -49,6 +50,9 @@ func Commands() *cobra.Command {
 				nmUsage(nil, err)
 			}
 			nmxutil.SetLogLevel(NewtmgrLogLevel)
+
+			// Set cbgo log level if we're using macOS.
+			OSSpecificInit()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)

--- a/newtmgr/cli/darwin.go
+++ b/newtmgr/cli/darwin.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package cli
+
+import (
+	"github.com/JuulLabs-OSS/cbgo"
+)
+
+func OSSpecificInit() {
+	cbgo.SetLogLevel(NewtmgrLogLevel)
+}

--- a/newtmgr/cli/notdarwin.go
+++ b/newtmgr/cli/notdarwin.go
@@ -1,0 +1,6 @@
+// +build !darwin
+
+package cli
+
+func OSSpecificInit() {
+}


### PR DESCRIPTION
This is a less buggy implementation of the mojave-support feature.  It
also adds some low level Bluetooth logging for macOS users (when -ldebug
is specified).