### PR TITLE
Freeze filter for `image upload` chunk length calculation

### DIFF
--- a/newtmgr/bll/bll_sesn.go
+++ b/newtmgr/bll/bll_sesn.go
@@ -276,7 +276,7 @@ func (s *BllSesn) openOnce() (bool, error) {
 			"Attempt to open an already-open bll session")
 	}
 
-	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilterCb, s.cfg.RxFilterCb, true,
+	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilter, s.cfg.RxFilter, true,
 		s.cfg.MgmtProto, 3)
 	if err != nil {
 		return false, err
@@ -416,12 +416,12 @@ func (s *BllSesn) CoapIsTcp() bool {
 	return true
 }
 
-func (s *BllSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *BllSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.txvr.Filters()
 }
 
-func (s *BllSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *BllSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.txvr.SetFilters(txFilter, rxFilter)
 }

--- a/newtmgr/bll/bll_sesn_cfg.go
+++ b/newtmgr/bll/bll_sesn_cfg.go
@@ -37,8 +37,8 @@ type BllSesnCfg struct {
 	ConnTimeout  time.Duration
 	ConnTries    int
 	WriteRsp     bool
-	TxFilterCb   nmcoap.MsgFilter
-	RxFilterCb   nmcoap.MsgFilter
+	TxFilter     nmcoap.TxMsgFilter
+	RxFilter     nmcoap.RxMsgFilter
 }
 
 func NewBllSesnCfg() BllSesnCfg {

--- a/newtmgr/cli/common.go
+++ b/newtmgr/cli/common.go
@@ -44,8 +44,8 @@ var globalP *config.ConnProfile
 // This keeps track of whether the global interface has been assigned.  This
 // is necessary to accommodate golang's nil-interface semantics.
 var globalXportSet bool
-var globalTxFilter nmcoap.MsgFilter
-var globalRxFilter nmcoap.MsgFilter
+var globalTxFilter nmcoap.TxMsgFilter
+var globalRxFilter nmcoap.RxMsgFilter
 
 func initConnProfile() error {
 	var p *config.ConnProfile
@@ -286,8 +286,8 @@ func buildBllSesn(cp *config.ConnProfile) (sesn.Sesn, error) {
 		return nil, util.NewNewtError("ERROR")
 	}
 
-	sc.TxFilterCb = globalTxFilter
-	sc.RxFilterCb = globalRxFilter
+	sc.TxFilter = globalTxFilter
+	sc.RxFilter = globalRxFilter
 
 	s, err := bx.BuildBllSesn(sc)
 	if err != nil {
@@ -320,8 +320,8 @@ func GetSesn() (sesn.Sesn, error) {
 		if err != nil {
 			return nil, err
 		}
-		sc.TxFilterCb = globalTxFilter
-		sc.RxFilterCb = globalRxFilter
+		sc.TxFilter = globalTxFilter
+		sc.RxFilter = globalRxFilter
 
 		x, err := GetXport()
 		if err != nil {
@@ -350,7 +350,7 @@ func GetSesnIfOpen() (sesn.Sesn, error) {
 	return globalSesn, nil
 }
 
-func SetFilters(txFilter nmcoap.MsgFilter, rxFilter nmcoap.MsgFilter) {
+func SetFilters(txFilter nmcoap.TxMsgFilter, rxFilter nmcoap.RxMsgFilter) {
 	globalTxFilter = txFilter
 	globalRxFilter = rxFilter
 }

--- a/nmxact/mtech_lora/mtech_lora_sesn.go
+++ b/nmxact/mtech_lora/mtech_lora_sesn.go
@@ -88,7 +88,7 @@ func (s *LoraSesn) Open() error {
 			"Attempt to open an already-open Lora session")
 	}
 
-	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilterCb, s.cfg.RxFilterCb, false,
+	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilter, s.cfg.RxFilter, false,
 		s.cfg.MgmtProto, 3)
 	if err != nil {
 		return err
@@ -369,8 +369,8 @@ func (s *LoraSesn) RxAccept() (sesn.Sesn, *sesn.SesnCfg, error) {
 			}
 			cl_s.cfg.Lora.ConfirmedTx = s.cfg.Lora.ConfirmedTx
 			cl_s.cfg.Lora.SegSz = s.cfg.Lora.SegSz
-			cl_s.cfg.TxFilterCb = s.cfg.TxFilterCb
-			cl_s.cfg.RxFilterCb = s.cfg.RxFilterCb
+			cl_s.cfg.TxFilter = s.cfg.TxFilter
+			cl_s.cfg.RxFilter = s.cfg.RxFilter
 			return cl_s, &cl_s.cfg, nil
 		case <-s.stopChan:
 			return nil, nil, fmt.Errorf("Session closed")
@@ -425,12 +425,12 @@ func (s *LoraSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 	}
 }
 
-func (s *LoraSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *LoraSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.txvr.Filters()
 }
 
-func (s *LoraSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *LoraSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.txvr.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/nmble/ble_sesn.go
+++ b/nmxact/nmble/ble_sesn.go
@@ -130,12 +130,12 @@ func (s *BleSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 	return s.Ns.RxCoap(opt)
 }
 
-func (s *BleSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *BleSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.Ns.Filters()
 }
 
-func (s *BleSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *BleSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.Ns.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/nmble/naked_sesn.go
+++ b/nmxact/nmble/naked_sesn.go
@@ -85,7 +85,7 @@ func (s *NakedSesn) init() error {
 		s.txvr.Stop()
 	}
 
-	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilterCb, s.cfg.RxFilterCb, true,
+	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilter, s.cfg.RxFilter, true,
 		s.cfg.MgmtProto, 3)
 	if err != nil {
 		return err
@@ -643,12 +643,12 @@ func (s *NakedSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 	return nil, fmt.Errorf("Op not implemented yet")
 }
 
-func (s *NakedSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *NakedSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.txvr.Filters()
 }
 
-func (s *NakedSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *NakedSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.txvr.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/nmcoap/nmcoap.go
+++ b/nmxact/nmcoap/nmcoap.go
@@ -38,7 +38,29 @@ const (
 	OBSERVE_STOP
 )
 
-type MsgFilter func(msg coap.Message) (coap.Message, error)
+type TxMsgFilter interface {
+	// Filter applies the filter to an outgoing CoAP message.
+	Filter(msg coap.Message) (coap.Message, error)
+
+	// Freeze makes the filter use the same parameters for all transmits until
+	// unfrozen.  The parameters will be different from the previous message,
+	// but they will not change while the session is frozen.
+	Freeze()
+
+	// Unfreeze makes the filter use new parameters for all subsequent
+	// messages.
+	Unfreeze()
+}
+
+type RxMsgFilter interface {
+	Filter(msg coap.Message) (coap.Message, error)
+}
+
+type RxFilterFunc func(msg coap.Message) (coap.Message, error)
+
+func (f RxFilterFunc) Filter(msg coap.Message) (coap.Message, error) {
+	return f(msg)
+}
 
 type MsgParams struct {
 	Code    coap.COAPCode

--- a/nmxact/nmserial/serial_sesn.go
+++ b/nmxact/nmserial/serial_sesn.go
@@ -57,7 +57,7 @@ func NewSerialSesn(sx *SerialXport, cfg sesn.SesnCfg) (*SerialSesn, error) {
 		sx:  sx,
 	}
 
-	txvr, err := mgmt.NewTransceiver(cfg.TxFilterCb, cfg.RxFilterCb, false,
+	txvr, err := mgmt.NewTransceiver(cfg.TxFilter, cfg.RxFilter, false,
 		cfg.MgmtProto, 3)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (s *SerialSesn) Open() error {
 			"Attempt to open an already-open serial session")
 	}
 
-	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilterCb, s.cfg.RxFilterCb, false,
+	txvr, err := mgmt.NewTransceiver(s.cfg.TxFilter, s.cfg.RxFilter, false,
 		s.cfg.MgmtProto, 3)
 	if err != nil {
 		s.m.Unlock()
@@ -321,12 +321,12 @@ func (s *SerialSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 	}
 }
 
-func (s *SerialSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *SerialSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.txvr.Filters()
 }
 
-func (s *SerialSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *SerialSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.txvr.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/nmserial/serial_xport.go
+++ b/nmxact/nmserial/serial_xport.go
@@ -83,8 +83,8 @@ func (sx *SerialXport) BuildSesn(cfg sesn.SesnCfg) (sesn.Sesn, error) {
 func (sx *SerialXport) acceptServerSesn(sl *SerialSesn) (*SerialSesn, error) {
 	sc := sesn.NewSesnCfg()
 	sc.MgmtProto = sesn.MGMT_PROTO_COAP_SERVER
-	sc.TxFilterCb = sl.cfg.TxFilterCb
-	sc.RxFilterCb = sl.cfg.RxFilterCb
+	sc.TxFilter = sl.cfg.TxFilter
+	sc.RxFilter = sl.cfg.RxFilter
 
 	s, err := NewSerialSesn(sx, sc)
 	if err != nil {

--- a/nmxact/omp/dispatch.go
+++ b/nmxact/omp/dispatch.go
@@ -42,13 +42,13 @@ type Dispatcher struct {
 	seqListenerMap map[uint8]*Listener
 	coapd          *nmcoap.Dispatcher
 	wg             sync.WaitGroup
-	rxFilter       nmcoap.MsgFilter
+	rxFilter       nmcoap.RxMsgFilter
 	stopped        bool
 	logDepth       int
 	mtx            sync.Mutex
 }
 
-func NewDispatcher(rxFilter nmcoap.MsgFilter, isTcp bool,
+func NewDispatcher(rxFilter nmcoap.RxMsgFilter, isTcp bool,
 	logDepth int) (*Dispatcher, error) {
 
 	d := &Dispatcher{
@@ -199,10 +199,10 @@ func (d *Dispatcher) ErrorAll(err error) {
 	d.coapd.ErrorAll(err)
 }
 
-func (d *Dispatcher) SetRxFilter(rxFilter nmcoap.MsgFilter) {
+func (d *Dispatcher) SetRxFilter(rxFilter nmcoap.RxMsgFilter) {
 	d.rxFilter = rxFilter
 }
 
-func (d *Dispatcher) RxFilter() nmcoap.MsgFilter {
+func (d *Dispatcher) RxFilter() nmcoap.RxMsgFilter {
 	return d.rxFilter
 }

--- a/nmxact/omp/omp.go
+++ b/nmxact/omp/omp.go
@@ -44,16 +44,16 @@ type OicMsg struct {
  * codec.  So we need to decode the whole response, and then re-encode the
  * newtmgr response part.
  */
-func DecodeOmp(m coap.Message, rxFilterCb nmcoap.MsgFilter) (nmp.NmpRsp, error) {
+func DecodeOmp(m coap.Message, rxFilter nmcoap.RxMsgFilter) (nmp.NmpRsp, error) {
 	// Ignore non-responses.
 	if m.Code() == coap.GET || m.Code() == coap.PUT || m.Code() == coap.POST ||
 		m.Code() == coap.DELETE {
 		return nil, nil
 	}
 
-	if rxFilterCb != nil {
+	if rxFilter != nil {
 		var err error
-		m, err = rxFilterCb(m)
+		m, err = rxFilter.Filter(m)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ type encodeRecord struct {
 	fieldMap map[string]interface{}
 }
 
-func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (encodeRecord, error) {
+func encodeOmpBase(txFilter nmcoap.TxMsgFilter, isTcp bool, nmr *nmp.NmpMsg) (encodeRecord, error) {
 	er := encodeRecord{}
 
 	mp := coap.MessageParams{
@@ -133,9 +133,9 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 	}
 	er.m.SetPayload(payload)
 
-	if txFilterCb != nil {
+	if txFilter != nil {
 		var err error
-		er.m, err = txFilterCb(er.m)
+		er.m, err = txFilter.Filter(er.m)
 		if err != nil {
 			return er, err
 		}
@@ -144,8 +144,8 @@ func encodeOmpBase(txFilterCb nmcoap.MsgFilter, isTcp bool, nmr *nmp.NmpMsg) (en
 	return er, nil
 }
 
-func EncodeOmpTcp(txFilterCb nmcoap.MsgFilter, nmr *nmp.NmpMsg) ([]byte, error) {
-	er, err := encodeOmpBase(txFilterCb, true, nmr)
+func EncodeOmpTcp(txFilter nmcoap.TxMsgFilter, nmr *nmp.NmpMsg) ([]byte, error) {
+	er, err := encodeOmpBase(txFilter, true, nmr)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,8 @@ func EncodeOmpTcp(txFilterCb nmcoap.MsgFilter, nmr *nmp.NmpMsg) ([]byte, error) 
 	return data, nil
 }
 
-func EncodeOmpDgram(txFilterCb nmcoap.MsgFilter, nmr *nmp.NmpMsg) ([]byte, error) {
-	er, err := encodeOmpBase(txFilterCb, false, nmr)
+func EncodeOmpDgram(txFilter nmcoap.TxMsgFilter, nmr *nmp.NmpMsg) ([]byte, error) {
+	er, err := encodeOmpBase(txFilter, false, nmr)
 	if err != nil {
 		return nil, err
 	}

--- a/nmxact/sesn/sesn.go
+++ b/nmxact/sesn/sesn.go
@@ -115,9 +115,9 @@ type Sesn interface {
 
 	// Returns a transmit and a receive callback used to manipulate CoAP
 	// messages
-	Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter)
+	Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter)
 
 	// Sets the transmit and a receive callback used to manipulate CoAP
 	// messages
-	SetFilters(txFilter nmcoap.MsgFilter, rxFilter nmcoap.MsgFilter)
+	SetFilters(txFilter nmcoap.TxMsgFilter, rxFilter nmcoap.RxMsgFilter)
 }

--- a/nmxact/sesn/sesn_cfg.go
+++ b/nmxact/sesn/sesn_cfg.go
@@ -86,9 +86,9 @@ type SesnCfg struct {
 	Ble  SesnCfgBle
 	Lora SesnCfgLora
 
-	// Callbacks
-	TxFilterCb nmcoap.MsgFilter
-	RxFilterCb nmcoap.MsgFilter
+	// Filters
+	TxFilter nmcoap.TxMsgFilter
+	RxFilter nmcoap.RxMsgFilter
 }
 
 func NewSesnCfg() SesnCfg {

--- a/nmxact/udp/udp_sesn.go
+++ b/nmxact/udp/udp_sesn.go
@@ -45,7 +45,7 @@ func NewUdpSesn(cfg sesn.SesnCfg) (*UdpSesn, error) {
 	s := &UdpSesn{
 		cfg: cfg,
 	}
-	txvr, err := mgmt.NewTransceiver(cfg.TxFilterCb, cfg.RxFilterCb, false,
+	txvr, err := mgmt.NewTransceiver(cfg.TxFilter, cfg.RxFilter, false,
 		cfg.MgmtProto, 3)
 	if err != nil {
 		return nil, err
@@ -156,12 +156,12 @@ func (s *UdpSesn) RxCoap(opt sesn.TxOptions) (coap.Message, error) {
 	return nil, fmt.Errorf("Op not implemented yet")
 }
 
-func (s *UdpSesn) Filters() (nmcoap.MsgFilter, nmcoap.MsgFilter) {
+func (s *UdpSesn) Filters() (nmcoap.TxMsgFilter, nmcoap.RxMsgFilter) {
 	return s.txvr.Filters()
 }
 
-func (s *UdpSesn) SetFilters(txFilter nmcoap.MsgFilter,
-	rxFilter nmcoap.MsgFilter) {
+func (s *UdpSesn) SetFilters(txFilter nmcoap.TxMsgFilter,
+	rxFilter nmcoap.RxMsgFilter) {
 
 	s.txvr.SetFilters(txFilter, rxFilter)
 }

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -136,6 +136,14 @@ func nextImageUploadReq(s sesn.Sesn, upgrade bool, data []byte, off int, imageNu
 	*nmp.ImageUploadReq, error) {
 	var hash []byte = nil
 
+	// Ensure we produce consistent requests while we calculate the chunk
+	// length.
+	txFilter, _ := s.Filters()
+	if txFilter != nil {
+		txFilter.Freeze()
+		defer txFilter.Unfreeze()
+	}
+
 	// For 1st chunk we'll need valid data hash
 	if off == 0 {
 		sha := sha256.Sum256(data)


### PR DESCRIPTION
To determine the correct amount of image data to put in an image upload request, newtmgr repeatedly generates requests until it finds the optimal value.  Each of these requests must be identical (aside from the payload size) or else the comparison is invalid.  If a `sesn`'s filter uses different parameters each time it encodes a message (e.g., if it does encryption), that breaks this method of determining the correct chunk size.
        
By freezing the filter, the same parameters get used for each subsequent message encoding.  This ensures the payload size won't change after we have settled on a chunk size.