### PR TITLE
transiever: fix compilation error

### DIFF
--- a/nmxact/mgmt/transceiver.go
+++ b/nmxact/mgmt/transceiver.go
@@ -219,9 +219,9 @@ func (t *Transceiver) txRxOmpAsync(txCb TxFn, req *nmp.NmpMsg, mtu int,
 
 	var b []byte
 	if t.isTcp {
-		b, err = omp.EncodeOmpTcp(t.txFilterCb, req)
+		b, err = omp.EncodeOmpTcp(t.txFilter, req)
 	} else {
-		b, err = omp.EncodeOmpDgram(t.txFilterCb, req)
+		b, err = omp.EncodeOmpDgram(t.txFilter, req)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
omp.EncodeOmpDgram now takes txFilter, not txFilterCb. Fix this.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>