### PR TITLE
nmxact: Fix image upload failure due to unsupported async method

### DIFF
--- a/nmxact/nmble/naked_sesn.go
+++ b/nmxact/nmble/naked_sesn.go
@@ -353,7 +353,13 @@ func (s *NakedSesn) TxRxMgmt(m *nmp.NmpMsg,
 
 func (s *NakedSesn) TxRxMgmtAsync(m *nmp.NmpMsg,
 	timeout time.Duration, ch chan nmp.NmpRsp, errc chan error) error {
-	return fmt.Errorf("unsupported")
+	rsp, err := s.TxRxMgmt(m, timeout)
+	if err != nil {
+		errc <- err
+	} else {
+		ch <- rsp
+	}
+	return nil
 }
 
 func (s *NakedSesn) ListenCoap(

--- a/nmxact/udp/udp_sesn.go
+++ b/nmxact/udp/udp_sesn.go
@@ -120,7 +120,13 @@ func (s *UdpSesn) TxRxMgmt(m *nmp.NmpMsg,
 
 func (s *UdpSesn) TxRxMgmtAsync(m *nmp.NmpMsg,
 	timeout time.Duration, ch chan nmp.NmpRsp, errc chan error) error {
-	return fmt.Errorf("unsupported")
+	rsp, err := s.TxRxMgmt(m, timeout)
+	if err != nil {
+		errc <- err
+	} else {
+		ch <- rsp
+	}
+	return nil
 }
 
 func (s *UdpSesn) AbortRx(seq uint8) error {


### PR DESCRIPTION
This addresses the UDP based image upload failure.

The UDP and naked sessons do not implement TxRxAsync
for optimized transfer as in BLE, however, continue to
support the operation by calling TxRxMgmt.

Failure signature:
```
~/go/bin/mcumgr --conntype udp --connstring=[192.168.1.1]:1337 image
upload build_f429/smpsvr/zephyr/zephyr.signed.bin
0 / 90644
[-----------------------------------------]
0.00%
Error: ImageUpload unexpected error after 0/90644 bytes
```
Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>