### PR TITLE
bll_sesn_cfg_windows: Fix build error for windows

### DIFF
--- a/newtmgr/bll/bll_sesn_cfg_windows.go
+++ b/newtmgr/bll/bll_sesn_cfg_windows.go
@@ -32,8 +32,8 @@ type BllSesnCfg struct {
 	MgmtProto    sesn.MgmtProto
 	PreferredMtu int
 	ConnTimeout  time.Duration
-	TxFilterCb   nmcoap.MsgFilter
-	RxFilterCb   nmcoap.MsgFilter
+	TxFilter     nmcoap.TxMsgFilter
+	RxFilter     nmcoap.RxMsgFilter
 }
 
 func NewBllSesnCfg() BllSesnCfg {


### PR DESCRIPTION
Commit 0663961 replaced callbacks
with interfaces (TxFilter and RxFilter). Apply the change for
the Windows specific implementation as well and fix the following
error.

```
C:\Users\ryan.erickson>go get github.com/apache/mynewt-mcumgr-cli/mcumgr
go\src\mynewt.apache.org\newtmgr\newtmgr\bll\bll_sesn_cfg_windows.go:35:15:
undefined: nmcoap.MsgFilter
go\src\mynewt.apache.org\newtmgr\newtmgr\bll\bll_sesn_cfg_windows.go:36:15:
undefined: nmcoap.MsgFilter
```
Building tested with:
`$GOOS=windows go build`

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>