### PR TITLE
taskstat: Add tab character after the task's name

### DIFF
--- a/newtmgr/cli/taskstat.go
+++ b/newtmgr/cli/taskstat.go
@@ -56,12 +56,12 @@ func taskStatRunCmd(cmd *cobra.Command, args []string) {
 	}
 	sort.Strings(names)
 
-	fmt.Printf("  %8s %3s %3s %8s %8s %8s %8s %8s %8s\n",
+	fmt.Printf("  %8s\t%3s %3s %8s %8s %8s %8s %8s %8s\n",
 		"task", "pri", "tid", "runtime", "csw", "stksz",
 		"stkuse", "last_checkin", "next_checkin")
 	for _, n := range names {
 		t := sres.Rsp.Tasks[n]
-		fmt.Printf("  %8s %3d %3d %8d %8d %8d %8d %8d %8d\n",
+		fmt.Printf("  %8s\t%3d %3d %8d %8d %8d %8d %8d %8d\n",
 			n,
 			t["prio"],
 			t["tid"],


### PR DESCRIPTION
- There was a space earlier and if the task name was bigger,
  it would cause formatting issues

*BEFORE*
```
Vipuls-MacBook-Pro-16-inch-2019:fw-signal vipul$ mcumgr --conntype ble --connstring peer_name=pr-8c1b taskstat
      task pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
    BT ECC  10   2        0        0      275      223        0        0
     BT RX 248   0        0        0     1024      105        0        0
  BT RX pri 246   1        0        0      112       43        0        0
     BT TX 247   3        0        0      160      102        0        0
   idle 00  15   5        0        0       80       14        0        0
      main   0   6        0        0     1024      358        0        0
  sysworkq 255   4        0        0      512      153        0        0
```

*AFTER*
```
      task	pri tid  runtime      csw    stksz   stkuse last_checkin next_checkin
    BT ECC	 10   2        0        0      275      223        0        0
     BT RX	248   0        0        0     1024      105        0        0
  BT RX pri	246   1        0        0      112       43        0        0
     BT TX	247   3        0        0      160      102        0        0
   idle 00	 15   5        0        0       80       14        0        0
      main	  0   6        0        0     1024      358        0        0
  sysworkq	255   4        0        0      512      153        0        0
```

Any other suggestions welcome.
