### PR TITLE
nmp decode: allow registration of custom response handlers

### DIFF
--- a/nmxact/nmp/decode.go
+++ b/nmxact/nmp/decode.go
@@ -124,3 +124,10 @@ func DecodeRspBody(hdr *NmpHdr, body []byte) (NmpRsp, error) {
 	r.SetHdr(hdr)
 	return r, nil
 }
+
+func RegisterResponseHandler (ogi Ogi, f rspCtor) {
+	cb := rspCtorMap[ogi]
+	if cb == nil {
+		rspCtorMap[ogi] = f
+	}
+}


### PR DESCRIPTION
This PR allows the to use custom  smp commands (e.g. using the peruser group). The implementation of the commands is not part of this PR since Go allowed me to extend the the library without forking the repo. The only thing that must be changed is the possibility to register the custom response handlers. @ccollins476ad could you please take a look at it?