### PR TITLE
Fix not working MTU exchange on newer versions of mac

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -21,6 +21,7 @@ package cli
 
 import (
 	"fmt"
+	"runtime"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -57,6 +58,11 @@ func Commands() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
+	}
+
+	if runtime.GOOS == "darwin" {
+		nmCmd.PersistentFlags().IntVarP(&nmutil.MtuOverride, "mtu-ovrd", "m", 0,
+			"Override MTU in case it can't be negotiated on Mac computers (slice out of range error)")
 	}
 
 	nmCmd.PersistentFlags().StringVarP(&nmutil.ConnProfile, "conn", "c", "",

--- a/newtmgr/nmutil/nmutil.go
+++ b/newtmgr/nmutil/nmutil.go
@@ -40,6 +40,7 @@ var Tries int
 var ConnProfile string
 var DeviceName string
 var BleWriteRsp bool
+var MtuOverride int
 var ConnType string
 var ConnString string
 var ConnExtra string

--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -148,6 +148,11 @@ func findChunkLen(s sesn.Sesn, hash []byte, upgrade bool, data []byte,
 		// Encoded length is larger than MTU, we need to make chunk shorter
 		overflow := len(enc) - s.MtuOut()
 		chunklen -= overflow
+		if chunklen <= 0 {
+			return 0, fmt.Errorf("Cannot create image upload request; "+
+				"MTU too low to fit any image data; max-payload-size=%d chunklen %d",
+				s.MtuOut(), chunklen)
+		}
 	}
 
 	return chunklen, nil


### PR DESCRIPTION
It seems like on newer versions of mac (e.g. Monterey) fix with looping three times to get right MTU doesn't work. Also for some strange reason default TxMTU is set to 17 instead of 23. Now user can set MTU from the command line (-m <MTU value>). If MTU is not set in the command line and after performing three loops MTU is still <23 we hardcode it to 185.