### PR TITLE
use the timeout from the command line

### DIFF
--- a/nmxact/xact/image.go
+++ b/nmxact/xact/image.go
@@ -495,7 +495,7 @@ func (c *ImageUpgradeCmd) runUpload(s sesn.Sesn) (*ImageUploadResult, error) {
 
 	for {
 		var opt = sesn.TxOptions{
-			Timeout: 3 * time.Second,
+			Timeout: c.CmdBase.txOptions.Timeout,
 			Tries:   1,
 		}
 		cmd := NewImageUploadCmd()


### PR DESCRIPTION
This patch changes the hardcoded 3 seconds timeout to the timeout which is actually specified at the command line, or the default 10 seconds if nothing is specified. The 3 seconds was not enough to write a flash image, when the erase time needs longer, as it is the case with Zephyr, when the incrementally erase option is not enabled.