### PR TITLE
logs: Add support for reading number of entries since an index for a particular log

### DIFF
--- a/newtmgr/cli/log.go
+++ b/newtmgr/cli/log.go
@@ -60,6 +60,35 @@ type logShowCfg struct {
 	Timestamp int64
 }
 
+type logNumEntriesCfg struct {
+	Name      string
+	Index     uint32
+}
+
+func logNumEntriesParseArgs(args []string) (*logNumEntriesCfg, error) {
+	cfg := &logNumEntriesCfg{}
+
+	if len(args) < 1 {
+		return cfg, nil
+	}
+	cfg.Name = args[0]
+
+	if len(args) < 2 {
+		cfg.Index = 0
+  } else {
+		u64, err := strconv.ParseUint(args[1], 0, 64)
+		if err != nil {
+			return nil, util.ChildNewtError(err)
+		}
+		if u64 > 0xffffffff {
+			return nil, util.NewNewtError("index out of range")
+		}
+		cfg.Index = uint32(u64)
+	}
+
+	return cfg, nil
+}
+
 func logShowParseArgs(args []string) (*logShowCfg, error) {
 	cfg := &logShowCfg{}
 
@@ -110,8 +139,8 @@ func printLogShowRsp(rsp *nmp.LogShowRsp, printHdr bool) {
 			fmt.Printf("Name: %s\n", log.Name)
 			fmt.Printf("Type: %s\n", nmp.LogTypeToString(log.Type))
 
-			fmt.Printf("%10s %22s | %16s %16s %6s %8s %s\n",
-				"[index]", "[timestamp]", "[module]", "[level]", "[type]",
+			fmt.Printf("%10s %10s %22s | %16s %16s %6s %8s %s\n",
+				"[num_entries]", "[index]", "[timestamp]", "[module]", "[level]", "[type]",
 				"[img]", "[message]")
 		}
 
@@ -145,7 +174,8 @@ func printLogShowRsp(rsp *nmp.LogShowRsp, printHdr bool) {
 				msgText = hex.EncodeToString(entry.Msg)
 			}
 
-			fmt.Printf("%10d %20dus | %16s %16s %6s %8s %s\n",
+			fmt.Printf("%10d %10d %20dus | %16s %16s %6s %8s %s\n",
+				entry.NumEntries,
 				entry.Index,
 				entry.Timestamp,
 				modText,
@@ -205,6 +235,20 @@ func logShowPartialCmd(s sesn.Sesn, cfg *logShowCfg) error {
 	}
 
 	return nil
+}
+
+func logNumEntriesCmd(cmd *cobra.Command, args []string) {
+	cfg, err := logNumEntriesParseArgs(args)
+	if err != nil {
+		nmUsage(cmd, err)
+	}
+
+	s, err := GetSesn()
+	if err != nil {
+		nmUsage(nil, err)
+	}
+
+  logNumEntriesProcCmd(s, cfg)
 }
 
 func logShowCmd(cmd *cobra.Command, args []string) {
@@ -286,6 +330,33 @@ func logModuleListCmd(cmd *cobra.Command, args []string) {
 	for _, name := range names {
 		fmt.Printf("    %s (%d)\n", name, sres.Rsp.Map[name])
 	}
+}
+
+func logNumEntriesProcCmd(s sesn.Sesn, cfg *logNumEntriesCfg) {
+	s, err := GetSesn()
+	if err != nil {
+		nmUsage(nil, err)
+	}
+
+	c := xact.NewLogNumEntriesCmd()
+	c.SetTxOptions(nmutil.TxOptions())
+	c.Name = cfg.Name
+	c.Index = cfg.Index
+
+	res, err := c.Run(s)
+	if err != nil {
+		nmUsage(nil, util.ChildNewtError(err))
+  }
+
+	sres := res.(*xact.LogNumEntriesResult)
+	if sres.Rsp.Rc != 0 {
+		fmt.Printf("error: %d\n", sres.Rsp.Rc)
+	  return;
+  }
+
+	fmt.Printf("Number of entries: %d\n", sres.Rsp.NumEntries)
+
+  return
 }
 
 func logLevelListCmd(cmd *cobra.Command, args []string) {
@@ -406,6 +477,14 @@ func logCmd() *cobra.Command {
 	}
 
 	logCmd.AddCommand(ListCmd)
+
+	NumEntriesCmd := &cobra.Command{
+		Use:   "num_entries [log-name [min-index]] -c <conn_profile>",
+		Short: "Show the number of entries from index for a particular log",
+		Run:   logNumEntriesCmd,
+	}
+
+	logCmd.AddCommand(NumEntriesCmd)
 
 	return logCmd
 }

--- a/nmxact/nmcoap/nmcoap.go
+++ b/nmxact/nmcoap/nmcoap.go
@@ -63,7 +63,7 @@ func (f RxFilterFunc) Filter(msg coap.Message) (coap.Message, error) {
 }
 
 type MsgParams struct {
-	Code    coap.COAPCode
+	Code    coap.Code
 	Uri     string
 	Observe ObserveCode
 	Token   []byte

--- a/nmxact/nmp/decode.go
+++ b/nmxact/nmp/decode.go
@@ -66,6 +66,7 @@ func logListRspCtor() NmpRsp       { return NewLogListRsp() }
 func logModuleListRspCtor() NmpRsp { return NewLogModuleListRsp() }
 func logLevelListRspCtor() NmpRsp  { return NewLogLevelListRsp() }
 func logClearRspCtor() NmpRsp      { return NewLogClearRsp() }
+func logNumEntriesRspCtor() NmpRsp { return NewLogNumEntriesRsp() }
 func crashRspCtor() NmpRsp         { return NewCrashRsp() }
 func runTestRspCtor() NmpRsp       { return NewRunTestRsp() }
 func runListRspCtor() NmpRsp       { return NewRunListRsp() }
@@ -96,6 +97,7 @@ var rspCtorMap = map[Ogi]rspCtor{
 	{op_rr, gr_log, NMP_ID_LOG_MODULE_LIST}:  logModuleListRspCtor,
 	{op_rr, gr_log, NMP_ID_LOG_LEVEL_LIST}:   logLevelListRspCtor,
 	{op_wr, gr_log, NMP_ID_LOG_CLEAR}:        logClearRspCtor,
+	{op_rr, gr_log, NMP_ID_LOG_NUM_ENTRIES}:  logNumEntriesRspCtor,
 	{op_wr, gr_cra, NMP_ID_CRASH_TRIGGER}:    crashRspCtor,
 	{op_wr, gr_run, NMP_ID_RUN_TEST}:         runTestRspCtor,
 	{op_rr, gr_run, NMP_ID_RUN_LIST}:         runListRspCtor,

--- a/nmxact/nmp/defs.go
+++ b/nmxact/nmp/defs.go
@@ -90,6 +90,7 @@ const (
 	NMP_ID_LOG_MODULE_LIST = 3
 	NMP_ID_LOG_LEVEL_LIST  = 4
 	NMP_ID_LOG_LIST        = 5
+	NMP_ID_LOG_NUM_ENTRIES = 6
 )
 
 // Crash group (5).

--- a/nmxact/nmp/log.go
+++ b/nmxact/nmp/log.go
@@ -130,13 +130,14 @@ type LogShowReq struct {
 }
 
 type LogEntry struct {
-	Index     uint32       `codec:"index"`
-	Timestamp int64        `codec:"ts"`
-	Module    uint8        `codec:"module"`
-	Level     uint8        `codec:"level"`
-	Type      LogEntryType `codec:"type"`
-	ImgHash   []byte       `codec:"imghash"`
-	Msg       []byte       `codec:"msg"`
+	NumEntries uint32       `codec:"num_entries"`
+	Index      uint32       `codec:"index"`
+	Timestamp  int64        `codec:"ts"`
+	Module     uint8        `codec:"module"`
+	Level      uint8        `codec:"level"`
+	Type       LogEntryType `codec:"type"`
+	ImgHash    []byte       `codec:"imghash"`
+	Msg        []byte       `codec:"msg"`
 }
 
 type LogShowLog struct {
@@ -165,6 +166,37 @@ func NewLogShowRsp() *LogShowRsp {
 }
 
 func (r *LogShowRsp) Msg() *NmpMsg { return MsgFromReq(r) }
+
+//////////////////////////////////////////////////////////////////////////////
+// $NumEntries                                                              //
+//////////////////////////////////////////////////////////////////////////////
+
+type LogNumEntriesReq struct {
+	NmpBase `codec:"-"`
+	Name      string `codec:"log_name"`
+	Index     uint32 `codec:"index"`
+}
+
+type LogNumEntriesRsp struct {
+	NmpBase
+	Rc         int      `codec:"rc"`
+	NumEntries uint32   `codec:"num_entries"`
+}
+
+func NewLogNumEntriesReq() *LogNumEntriesReq {
+	r := &LogNumEntriesReq{}
+	fillNmpReq(r, NMP_OP_READ, NMP_GROUP_LOG, NMP_ID_LOG_NUM_ENTRIES)
+	return r
+}
+
+func (r *LogNumEntriesReq) Msg() *NmpMsg { return MsgFromReq(r) }
+
+func NewLogNumEntriesRsp() *LogNumEntriesRsp {
+	return &LogNumEntriesRsp{}
+}
+
+func (r *LogNumEntriesRsp) Msg() *NmpMsg { return MsgFromReq(r) }
+
 
 //////////////////////////////////////////////////////////////////////////////
 // $list                                                                    //

--- a/nmxact/xact/log.go
+++ b/nmxact/xact/log.go
@@ -233,6 +233,49 @@ func (c *LogModuleListCmd) Run(s sesn.Sesn) (Result, error) {
 	res.Rsp = srsp
 	return res, nil
 }
+//////////////////////////////////////////////////////////////////////////////
+// $Num Entries                                                             //
+//////////////////////////////////////////////////////////////////////////////
+
+type LogNumEntriesCmd struct {
+	CmdBase
+	Name      string
+	Index     uint32
+}
+
+func NewLogNumEntriesCmd() *LogNumEntriesCmd {
+	return &LogNumEntriesCmd{
+		CmdBase: NewCmdBase(),
+	}
+}
+
+type LogNumEntriesResult struct {
+	Rsp *nmp.LogNumEntriesRsp
+}
+
+func newLogNumEntriesResult() *LogNumEntriesResult {
+	return &LogNumEntriesResult{}
+}
+
+func (r *LogNumEntriesResult) Status() int {
+	return r.Rsp.Rc
+}
+
+func (c *LogNumEntriesCmd) Run(s sesn.Sesn) (Result, error) {
+	r := nmp.NewLogNumEntriesReq()
+	r.Name = c.Name
+	r.Index = c.Index
+
+	rsp, err := txReq(s, r.Msg(), &c.CmdBase)
+	if err != nil {
+		return nil, err
+	}
+	srsp := rsp.(*nmp.LogNumEntriesRsp)
+
+	res := newLogNumEntriesResult()
+	res.Rsp = srsp
+	return res, nil
+}
 
 //////////////////////////////////////////////////////////////////////////////
 // $level list                                                              //


### PR DESCRIPTION
Related mcumgr PR: https://github.com/apache/mynewt-mcumgr/pull/172
Related mynewt-core PR: https://github.com/apache/mynewt-core/pull/3168

Example:
Successful/Valid case:
```
$newtmgr --connstring peer_name="my_dev" --conntype oic_ble log num_entries reboot_log 0
Number of entries: 43
```
Error case:
```
<Invalid log>
$newtmgr --connstring peer_name="my_dev" --conntype oic_ble log num_entries reboot 0
error: 5

<Invalid index>
$newtmgr --connstring peer_name="my_dev" --conntype oic_ble log num_entries reboot 4000
error: 5
```