### PR TITLE
Fix CoAP over serial fragmentation problem

### DIFF
--- a/newtmgr/bll/bll_sesn.go
+++ b/newtmgr/bll/bll_sesn.go
@@ -415,10 +415,16 @@ func (s *BllSesn) TxRxMgmtAsync(m *nmp.NmpMsg,
 
 func (s *BllSesn) TxCoap(m coap.Message) error {
 	txRaw := func(b []byte) error {
-		return s.txWriteCharacteristic(s.resReqChr, b, !s.cfg.WriteRsp)
+		frags := nmxutil.Fragment(b, s.MtuOut())
+		for _, frag := range frags {
+			if err := s.txWriteCharacteristic(s.resReqChr, frag, !s.cfg.WriteRsp); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
-	return s.txvr.TxCoap(txRaw, m, s.MtuOut())
+	return s.txvr.TxCoap(txRaw, m)
 }
 
 func (s *BllSesn) ListenCoap(mc nmcoap.MsgCriteria) (*nmcoap.Listener, error) {

--- a/nmxact/mgmt/transceiver.go
+++ b/nmxact/mgmt/transceiver.go
@@ -284,18 +284,16 @@ func (t *Transceiver) TxRxMgmtAsync(txCb TxFn, req *nmp.NmpMsg, mtu int,
 	}
 }
 
-func (t *Transceiver) TxCoap(txCb TxFn, req coap.Message, mtu int) error {
+func (t *Transceiver) TxCoap(txCb TxFn, req coap.Message) error {
 	b, err := nmcoap.Encode(req)
 	if err != nil {
 		return err
 	}
 
 	log.Debugf("tx CoAP request: %s", hex.Dump(b))
-	frags := nmxutil.Fragment(b, mtu)
-	for _, frag := range frags {
-		if err := txCb(frag); err != nil {
-			return err
-		}
+
+	if err := txCb(b); err != nil {
+		return err
 	}
 
 	return nil

--- a/nmxact/mtech_lora/mtech_lora_sesn.go
+++ b/nmxact/mtech_lora/mtech_lora_sesn.go
@@ -339,7 +339,7 @@ func (s *LoraSesn) TxCoap(m coap.Message) error {
 			"Attempt to transmit over closed Lora session")
 	}
 
-	return s.txvr.TxCoap(s.sendFragments, m, s.MtuOut())
+	return s.txvr.TxCoap(s.sendFragments, m)
 }
 
 func (s *LoraSesn) ListenCoap(mc nmcoap.MsgCriteria) (*nmcoap.Listener, error) {

--- a/nmxact/nmserial/serial_sesn.go
+++ b/nmxact/nmserial/serial_sesn.go
@@ -236,7 +236,7 @@ func (s *SerialSesn) TxCoap(m coap.Message) error {
 		return err
 	}
 
-	return s.txvr.TxCoap(s.sx.Tx, m, s.MtuOut())
+	return s.txvr.TxCoap(s.sx.Tx, m)
 }
 
 func (s *SerialSesn) ListenCoap(

--- a/nmxact/udp/udp_sesn.go
+++ b/nmxact/udp/udp_sesn.go
@@ -136,11 +136,16 @@ func (s *UdpSesn) AbortRx(seq uint8) error {
 
 func (s *UdpSesn) TxCoap(m coap.Message) error {
 	txRaw := func(b []byte) error {
-		_, err := s.conn.WriteToUDP(b, s.addr)
-		return err
+		frags := nmxutil.Fragment(b, s.MtuOut())
+		for _, frag := range frags {
+			if _, err := s.conn.WriteToUDP(frag, s.addr); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
-	return s.txvr.TxCoap(txRaw, m, s.MtuOut())
+	return s.txvr.TxCoap(txRaw, m)
 }
 
 func (s *UdpSesn) MgmtProto() sesn.MgmtProto {


### PR DESCRIPTION
When sending large packets over serial newtmgr was fragmenting them twice in case of using CoAP over serial. First fragmentation was performed inside Transceiver's TxCoap method,
before passing data to Tx method from SerialXport module. Tx method from SerialXport then would once again fragment data with the same MTU, but on this stage each fragment would get a packet stat designator, which is necessary to determine if a specific fragment is a start of new packet or continuing one. Because of previous data fragmentation, each fragment was passed to SerialXport Tx method individualy and each of this fragments was incorrectly interpreted as a starting of a new packet.

To solve this issue, the fragmentation was moved from Transceiver's TxCoap method to txCb functions, so now every kind of transport can implement it's own fragmentation.