### PR TITLE
documentation/sphinx: Fix formatting errors in `.rst` files

### DIFF
--- a/docs/command_list/newtmgr_mpstats.rst
+++ b/docs/command_list/newtmgr_mpstats.rst
@@ -44,7 +44,7 @@ Examples
 +-----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Here is an example output for the ``myble`` application from the
-:doc:`Enabling Newt Manager in any app <../../os/tutorials/add_newtmgr>` tutiorial:
+:doc:`Enabling Newt Manager in any app <../../tutorials/devmgmt/add_newtmgr>` tutiorial:
 
 .. code-block:: console
 

--- a/docs/command_list/newtmgr_stat.rst
+++ b/docs/command_list/newtmgr_stat.rst
@@ -49,7 +49,7 @@ Examples
 +---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Here are some example outputs for the ``myble`` application from the
-:doc:`Enabling Newt Manager in any app <../../os/tutorials/add_newtmgr>` tutiorial:
+:doc:`Enabling Newt Manager in any app <../../tutorials/devmgmt/add_newtmgr>` tutiorial:
 
 The statistics for the ble_att Stats:
 

--- a/docs/command_list/newtmgr_taskstats.rst
+++ b/docs/command_list/newtmgr_taskstats.rst
@@ -47,7 +47,7 @@ Examples
 +-----------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Here is an example output for the ``myble`` application from the
-:doc:`Enabling Newt Manager in any app <../../os/tutorials/add_newtmgr>` tutorial:
+:doc:`Enabling Newt Manager in any app <../../tutorials/devmgmt/add_newtmgr>` tutorial:
 
 .. code-block:: console
 

--- a/docs/install/install_mac.rst
+++ b/docs/install/install_mac.rst
@@ -63,7 +63,7 @@ newtmgr:
     ==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.4.1/mynewt-newtmgr-1.4.1.sierra.bottle.tar.gz
     ######################################################################## 100.0%
     ==> Pouring mynewt-newtmgr-1.4.1.sierra.bottle.tar.gz
-    🍺  /usr/local/Cellar/mynewt-newtmgr/1.4.1: 3 files, 17.3MB
+        /usr/local/Cellar/mynewt-newtmgr/1.4.1: 3 files, 17.3MB
 
 **Notes:** Homebrew bottles for newtmgr 1.4.1 are available for Mac OS
 Sierra, El Captian. If you are running an earlier version of Mac OS, the
@@ -160,7 +160,7 @@ Install the latest unstable version of newtmgr from the master branch:
     ==> go get github.com/raff/goble
     ==> go get github.com/mgutz/logxi/v1
     ==> go install
-    🍺  /usr/local/Cellar/mynewt-newtmgr/HEAD-2d5217f: 3 files, 17.3MB, built in 1 minute 10 seconds
+        /usr/local/Cellar/mynewt-newtmgr/HEAD-2d5217f: 3 files, 17.3MB, built in 1 minute 10 seconds
 
 To switch back to the latest stable release version of newtmgr, you can
 run:

--- a/docs/install/install_windows.rst
+++ b/docs/install/install_windows.rst
@@ -55,8 +55,7 @@ tested on Windows 10 64 bit platform.
      
           tar -xzf /tmp/apache-mynewt-newtmgr-bin-windows-1.4.1.tgz -C /usr/bin
 
-4. Verify the installed version of newtmgr. See `Checking the Installed
-   Version <#check_newtmgr>`__.
+4. Verify the installed version of newtmgr. See :ref:`Checking the Installed Version`_.
 
 Installing the Latest Release of Newtmgr from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes broken references to other documents/sections. Removes emojis from code snippets causing issues with LaTeX output generated by Sphinx.